### PR TITLE
Codex対応の導入（起動/設定/指示書/ドキュメント整備）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 !instructions/shogun.md
 !instructions/karo.md
 !instructions/ashigaru.md
+!instructions/codex-*.md
 
 # Startup script
 !shutsujin_departure.sh

--- a/instructions/codex-ashigaru.md
+++ b/instructions/codex-ashigaru.md
@@ -1,0 +1,33 @@
+---
+# ============================================================
+# Ashigaru Configuration (Codex) - YAML Front Matter
+# ============================================================
+# Thin Codex addendum. Read the upstream Ashigaru instructions for the full workflow.
+
+role: ashigaru
+version: "2.1-codex"
+agent: codex
+---
+
+# Codex Mode (Ashigaru) — Addendum
+
+## Read Order (Mandatory)
+
+1. `CLAUDE.md` (mailbox protocol, /clear recovery procedure, forbidden actions)
+2. `instructions/ashigaru.md` (primary ashigaru workflow)
+
+## Codex-Specific Differences
+
+- Codex uses `/new` (not `/clear`) to start a fresh session.
+  - If you receive `type: clear_command`, `inbox_watcher.sh` will run `/new` automatically in Codex mode.
+- Codex `/model` requires the picker UI (inline args are unreliable).
+  - `type: model_switch` is handled by `inbox_watcher.sh` (auto preset selection).
+
+## After Reading
+
+Reply with **only**:
+
+`ready`
+
+Then wait for inbox/tasks.
+

--- a/instructions/codex-karo.md
+++ b/instructions/codex-karo.md
@@ -1,0 +1,35 @@
+---
+# ============================================================
+# Karo Configuration (Codex) - YAML Front Matter
+# ============================================================
+# Thin Codex addendum. Read the upstream Karo instructions for the full workflow.
+
+role: karo
+version: "2.1-codex"
+agent: codex
+---
+
+# Codex Mode (Karo) — Addendum
+
+## Read Order (Mandatory)
+
+1. `CLAUDE.md` (mailbox protocol, recovery, forbidden actions)
+2. `instructions/karo.md` (primary karo workflow)
+
+## Codex-Specific Differences
+
+- `/clear` is not available in Codex.
+  - Do **not** send `/clear` manually.
+  - Use `type: clear_command` inbox messages; `inbox_watcher.sh` will translate to `/new` in Codex mode.
+- `/model` inline args are not supported in Codex.
+  - Use `type: model_switch` (legacy content like `/model opus` or `/model sonnet` is treated as a hint).
+  - `inbox_watcher.sh` will open `/model` and select a Codex auto preset.
+
+## After Reading
+
+Reply with **only**:
+
+`ready`
+
+Then wait for inbox/tasks.
+

--- a/instructions/codex-shogun.md
+++ b/instructions/codex-shogun.md
@@ -1,0 +1,35 @@
+---
+# ============================================================
+# Shogun Configuration (Codex) - YAML Front Matter
+# ============================================================
+# Structured metadata. This file is a thin Codex addendum that defers to the
+# upstream shogun instructions for the main workflow.
+
+role: shogun
+version: "2.1-codex"
+agent: codex
+---
+
+# Codex Mode (Shogun) — Addendum
+
+## Read Order (Mandatory)
+
+1. `CLAUDE.md` (mailbox protocol, recovery, forbidden actions)
+2. `instructions/shogun.md` (primary shogun workflow)
+
+## Codex-Specific Differences
+
+- Codex does not have `/clear`.
+  - If you receive `type: clear_command`, the infrastructure (`inbox_watcher.sh`) will run `/new` instead.
+- Codex does not support inline args for `/model` (e.g. `"/model opus"` typed as chat can be treated as a normal message).
+  - If you receive `type: model_switch`, the infrastructure maps it to Codex `/model` auto presets.
+- If Codex looks "idle" after startup, ensure you received the initial bootstrap prompt and replied once; `--enable steer` makes Enter submit immediately.
+
+## After Reading
+
+Reply with **only**:
+
+`ready`
+
+Then wait for tasks (inbox/tasks).
+


### PR DESCRIPTION
殿へ上申いたします。

## 概要
現行 main の **mailbox アーキテクチャ（inbox_write.sh + inbox_watcher.sh）** を崩さず、運用を **Claude Code に加え OpenAI Codex CLI でも**行えるよう最小差分で対応いたしました。

## 変更点（最小スコープ）
- `shutsujin_departure.sh`
  - `config/settings.yaml` の `agent: claude|codex` を読み取り、起動CLIを切替
  - Codex 起動時:
    - `-m/--model` でモデル指定（未設定時は Codex 既定にフォールバック）
    - `-c model_reasoning_effort=...` で思考深度指定（shogun/worker 別）
    - `--enable steer` を既定付与（Enter が即送信になり「入力は入るが送信されない」症状を回避）
  - **Bash 3.2 対応**: `&>>` を `>> ... 2>&1` に置換（macOS での構文エラー回避）
  - Codex は `CLAUDE.md` を自動読込しないため、起動後に **最小ブートストラップ指令**を注入し、`CLAUDE.md` + `instructions/codex-*.md` を読む運用へ誘導

- `scripts/inbox_watcher.sh`
  - `type: clear_command`:
    - Claude: `/clear`
    - Codex: `/new`
  - `type: model_switch`:
    - Claude: 既存どおり content をコマンドとして配信
    - Codex: `/model` ピッカーを開き、auto preset を数字で選択（content はヒント扱い: sonnet→fast / opus→thorough / balanced→balanced）

- `instructions/codex-*.md`（新規）
  - 既存 `instructions/*.md` を正としつつ、Codex 固有差分（/new, /model など）だけを追記する薄いアドエンドゥム

- `.gitignore`
  - OSS公開対象に `instructions/codex-*.md` を追加

## 影響範囲
- `agent` 未設定時は従来どおり Claude Code で起動します（後方互換）。
- mailbox の思想（YAML正本・nudge最小・ポーリング禁止）を維持します。

## 設定例（ローカルの config/settings.yaml）
```yaml
agent: codex

codex:
  # 任意: 未設定なら Codex 既定
  model: gpt-5.3-codex

  # 任意
  shogun_reasoning: high
  worker_reasoning: medium

  # 任意: 未設定なら --dangerously-bypass-approvals-and-sandbox --enable steer
  options: "--dangerously-bypass-approvals-and-sandbox"
```

## 備考（統合設計について）
PR #10 の `lib/cli_adapter.sh` とは未統合です。
まずは main の陣替え後にコンフリクトなく取り込める **最小の Codex 対応**に絞り、以後の統合（CLI抽象化への寄せ）をご相談できればと存じます。

以上でございりまする。
