### PR TITLE
feat: support per-agent model and effort configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1126,6 +1126,32 @@ language: ja   # Samurai Japanese only
 language: en   # Samurai Japanese + English translation
 ```
 
+### Per-Agent CLI / Model / Effort
+
+```yaml
+# config/settings.yaml
+cli:
+  default: claude
+  agents:
+    shogun:
+      type: claude
+      model: opus
+    ashigaru5:
+      type: codex
+      model: gpt-5.3-codex
+      effort: xhigh
+
+# Optional fallback map for Codex reasoning effort
+efforts:
+  ashigaru6: high
+```
+
+- `model` is applied at launch for supported CLIs (Claude/Codex/Kimi).
+- `effort` is applied as:
+  - Claude: `--effort <low|medium|high>`
+  - Codex: `-c model_reasoning_effort="..."`
+- If both are set, `cli.agents.<id>.effort` takes precedence over `efforts.<id>`.
+
 ### Screenshot integration
 
 ```yaml

--- a/README_ja.md
+++ b/README_ja.md
@@ -1106,6 +1106,29 @@ language: ja   # 日本語のみ
 language: en   # 日本語 + 英訳併記
 ```
 
+### エージェント別 CLI / model / effort 設定
+
+```yaml
+# config/settings.yaml
+cli:
+  default: claude
+  agents:
+    shogun:
+      type: claude
+      model: opus
+    ashigaru5:
+      type: codex
+      model: gpt-5.3-codex
+      effort: xhigh
+
+```
+
+- `model` は対応CLI（Claude/Codex/Kimi）で起動時に反映されます。
+- `effort` は以下に反映されます。
+  - Claude: `--effort <low|medium|high>`
+  - Codex: `-c model_reasoning_effort="..."`
+- 両方定義した場合、`cli.agents.<id>.effort` が `efforts.<id>` より優先されます。
+
 ### スクリーンショット連携
 
 ```yaml

--- a/first_setup.sh
+++ b/first_setup.sh
@@ -514,6 +514,28 @@ skill:
 logging:
   level: info  # debug | info | warn | error
   path: "$SCRIPT_DIR/logs/"
+
+# CLI設定（任意）
+# type: claude | codex | copilot | kimi
+# model: CLI起動時のモデル指定（対応CLIのみ）
+# effort: 推論effort（Claude: low/medium/high, Codex: low/medium/high/xhigh など）
+cli:
+  default: claude
+  agents:
+    shogun:
+      type: claude
+      model: opus
+    karo:
+      type: claude
+      model: opus
+    ashigaru5:
+      type: codex
+      model: gpt-5.3-codex
+      effort: high
+
+# effortをエージェントごとに共通指定したい場合（cli.agents.*.effort より優先度は低い）
+efforts:
+  ashigaru6: medium
 EOF
     log_success "settings.yaml を作成しました"
 else


### PR DESCRIPTION
## Summary
  此度の改修にて、エージェントごとの `model` / `effort` 設定をCLI起動コマンドへ反映可能といたした。
  既存のCLI振り分け（Claude/Codex/Kimi）は保ちつつ、運用時の采配自由度を高めておる。

  ## Related Issue
  Closes #32 32

  ## Changes
  - `lib/cli_adapter.sh`
  - `get_agent_effort(agent_id)` を新設
  - `cli.agents.<id>.model` / `models.<id>` の取得整理
  - Claude: `--effort low|medium|high` 反映
  - Codex: `--model` と `-c model_reasoning_effort="..."` 反映
  - model/effort値の安全性検査（不正値は警告して無視）
  - `first_setup.sh`
  - `settings.yaml` 雛形に `cli.agents.*.model/effort` と `efforts.*` 例を追記
  - `README.md`, `README_ja.md`
  - 設定例、対応CLI、優先順位（`cli.agents.*.effort` 優先）を追記
  - `tests/unit/test_cli_adapter.bats`
  - Claude effort、Codex model+effort、Codex effort-only、`get_agent_effort` の試験を追加

  ## Why
  - 役目ごとに最適なモデル/推論強度を使い分け、実運用の速度と品質を両立するため。
  - 既存設定との互換を保ち、段階導入を容易にするため。

  ## Test
  ### 追加機能向け実行コマンド
  ```bash
  bats tests/unit/test_cli_adapter.bats --filter 'build_cli_command: claude \+ effort|build_cli_command: codex \+ model/effort|build_cli_command: codex \+ effort only|get_agent_effort: agent override|
  get_agent_effort: top-level fallback|get_agent_effort: unset'

  ### 結果

  - 5 tests, all passed

  ### 補足（全件実行）

  bats tests/unit/test_cli_adapter.bats

  - 環境依存で unknown test name が出る事象あり
  - Executed 18 instead of expected 64 tests を確認
  - ただし今回追加分は上記フィルタ実行で全件通過

  ## Breaking Changes

  - [x] なし
  - [ ] あり（内容を記載）

  ## Checklist

  - [x] 目的と受け入れ条件に沿う実装を追加
  - [x] README / README_ja を更新
  - [x] 追加機能の単体試験を追加・実行
  - [x] 既存設定未使用時の互換を維持