### PR TITLE
cfix: align install path/docs and model label displayセットアップ時の案内文と実装の不一致を修正し、あわせて tmux ペインのモデル表示不整合を修正しました。

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -126,11 +126,11 @@ echo   ^|                                                            ^|
 echo   ^|  First time only / 初回のみ:                               ^|
 echo   ^|    1. Set username and password when prompted              ^|
 echo   ^|       ユーザー名とパスワードを設定                        ^|
-echo   ^|    2. cd /mnt/c/tools/feature-shogun                      ^|
+echo   ^|    2. cd /mnt/c/tools/multi-agent-shogun                      ^|
 echo   ^|    3. ./first_setup.sh                                    ^|
 echo   ^|                                                            ^|
 echo   ^|  Every time you use / 使うたびに:                          ^|
-echo   ^|    cd /mnt/c/tools/feature-shogun                          ^|
+echo   ^|    cd /mnt/c/tools/multi-agent-shogun                          ^|
 echo   ^|    ./shutsujin_departure.sh                                ^|
 echo   ^|                                                            ^|
 echo   +------------------------------------------------------------+

--- a/shutsujin_departure.sh
+++ b/shutsujin_departure.sh
@@ -538,6 +538,7 @@ if [ "$CLI_ADAPTER_LOADED" = true ]; then
     for i in {0..8}; do
         _agent="${AGENT_IDS[$i]}"
         _cli=$(get_cli_type "$_agent")
+        _model=$(get_agent_model "$_agent")
         case "$_cli" in
             codex)
                 # config.tomlから推論レベルを取得（表示は短縮形）
@@ -550,6 +551,14 @@ if [ "$CLI_ADAPTER_LOADED" = true ]; then
                 ;;
             kimi)
                 MODEL_NAMES[$i]="Kimi"
+                ;;
+            claude)
+                case "$_model" in
+                    opus)   MODEL_NAMES[$i]="Opus" ;;
+                    sonnet) MODEL_NAMES[$i]="Sonnet" ;;
+                    haiku)  MODEL_NAMES[$i]="Haiku" ;;
+                    *)      MODEL_NAMES[$i]="Opus" ;;
+                esac
                 ;;
         esac
     done


### PR DESCRIPTION
初めて、pull requestを書くのとコードについてさっぱりわかっていないので、多々間違っていることはあると思いますが、ご了承ください。自分の環境に導入をする際にcodexに相談しながら導入をしました。その時にひっかかった点が記載されています。


## 変更内容

1. install.bat
- 案内先パスを以下へ修正
  - 変更前: `/mnt/c/tools/feature-shogun`
  - 変更後: `/mnt/c/tools/multi-agent-shogun`
- インストーラの動作自体は変更せず、案内文のみの修正です。

2. README_ja.md
- クイックスタート/セットアップ説明を現行実装に合わせて更新。
- キュー/ダッシュボードのリセットは `-c/--clean` 指定時のみである点を明記。
- install.bat / first_setup.sh / shutsujin_departure.sh の役割説明を実態に合わせて整理。
- tmux ターゲット名など、実行コマンド例の一部を現行仕様に合わせて更新。

3. shutsujin_departure.sh
- Claude系エージェントの `@model_name` 表示を設定値ベースに修正。
- `get_agent_model` の結果（`opus` / `sonnet` / `haiku`）を使ってペイン表示名を決定するように変更。
- これにより、実際は Opus 設定なのに表示が Sonnet になる不整合を解消。

## 目的
- 初回導入時の混乱を減らす（古いパス案内の解消）。
- README の説明と実装の齟齬を減らす。
- tmux の表示を実際の設定と一致させる。

## 影響範囲
- 実行ロジックへの影響は最小で、主に案内/ドキュメント整合性と表示整合性の改善です。

## 確認内容
- install.bat の案内先が `/mnt/c/tools/multi-agent-shogun` になっていることを確認。
- `config/settings.yaml` で `ashigaru1/2 = claude + opus` の際、tmux 表示が `Opus` になることを確認。
- README_ja の説明が現行スクリプト挙動と一致していることを確認。

## 補足
- 修正案の作成・整理に Codex 5.3 を利用しました。