### PR TITLE
Fix/shogun single pane nudge lock

### DIFF
--- a/scripts/inbox_watcher.sh
+++ b/scripts/inbox_watcher.sh
@@ -547,8 +547,12 @@ pane_is_active() {
 }
 
 # ─── Session attach detection ───
-# Returns 0 if the session containing PANE_TARGET has at least one client attached.
-# When detached, no human is watching — safe to send-keys even to shogun.
+# Function: session_has_client
+# Description: Checks if the tmux session containing PANE_TARGET has at least
+#   one client attached. Used to avoid suppressing send-keys when no human is
+#   watching (e.g. single-pane shogun session where pane_is_active is always true).
+# Arguments: none (uses global PANE_TARGET)
+# Returns: 0 if at least one client is attached, 1 otherwise
 session_has_client() {
     local session_name
     session_name=$(timeout 2 tmux display-message -p -t "$PANE_TARGET" '#{session_name}' 2>/dev/null || true)

--- a/tests/unit/test_send_wakeup.bats
+++ b/tests/unit/test_send_wakeup.bats
@@ -36,6 +36,10 @@
 #   T-CODEX-010: unresolved CLI type falls back to codex-safe path
 #   T-CODEX-011: clear_command処理でauto-recovery task_assignedを自動投入
 #   T-CODEX-012: auto-recovery task_assignedは重複投入しない
+#   T-SHOGUN-001: session_has_client — returns 0 when client attached
+#   T-SHOGUN-002: session_has_client — returns 1 when no client
+#   T-SHOGUN-003: send_wakeup — shogun + active + attached → display-message only
+#   T-SHOGUN-004: send_wakeup — shogun + active + detached → send-keys fallthrough
 #   T-COPILOT-001: send_cli_command — copilot /clear → Ctrl-C + restart
 #   T-COPILOT-002: send_cli_command — copilot /model → skip
 
@@ -71,6 +75,8 @@ MOCK
     export MOCK_CAPTURE_PANE=""
     export MOCK_SENDKEYS_RC=0
     export MOCK_PANE_CLI=""
+    export MOCK_PANE_ACTIVE=""
+    export MOCK_LIST_CLIENTS=""
 
     # Test harness: sets up mocks, then sources the REAL inbox_watcher.sh
     # __INBOX_WATCHER_TESTING__=1 skips arg parsing, inotifywait check, and main loop.
@@ -100,8 +106,16 @@ tmux() {
         echo "\${MOCK_PANE_CLI:-}"
         return 0
     fi
+    if echo "\$*" | grep -q "list-clients"; then
+        [ -n "\${MOCK_LIST_CLIENTS:-}" ] && echo "\$MOCK_LIST_CLIENTS"
+        return 0
+    fi
     if echo "\$*" | grep -q "display-message"; then
-        echo "mock_pane"
+        if echo "\$*" | grep -q "pane_active"; then
+            echo "\${MOCK_PANE_ACTIVE:-0}"
+        else
+            echo "mock_session"
+        fi
         return 0
     fi
     return 0
@@ -708,4 +722,64 @@ PY
 
     ! grep -q "send-keys.*/model" "$MOCK_LOG"
     echo "$output" | grep -q "not supported on copilot"
+}
+
+# --- T-SHOGUN-001: session_has_client — client attached ---
+
+@test "T-SHOGUN-001: session_has_client returns 0 when client attached" {
+    run bash -c '
+        MOCK_LIST_CLIENTS="/dev/pts/1: mock_session [200x50 xterm-256color]"
+        source "'"$TEST_HARNESS"'"
+        session_has_client
+    '
+    [ "$status" -eq 0 ]
+}
+
+# --- T-SHOGUN-002: session_has_client — no client ---
+
+@test "T-SHOGUN-002: session_has_client returns 1 when no client" {
+    run bash -c '
+        MOCK_LIST_CLIENTS=""
+        source "'"$TEST_HARNESS"'"
+        session_has_client
+    '
+    [ "$status" -ne 0 ]
+}
+
+# --- T-SHOGUN-003: shogun + active pane + client attached → display-message only ---
+
+@test "T-SHOGUN-003: send_wakeup shogun + active + attached uses display-message only" {
+    run bash -c '
+        MOCK_PANE_ACTIVE="1"
+        MOCK_LIST_CLIENTS="/dev/pts/1: mock_session [200x50 xterm-256color]"
+        source "'"$TEST_HARNESS"'"
+        AGENT_ID="shogun"
+        send_wakeup 2
+    '
+    [ "$status" -eq 0 ]
+
+    # display-message was used for nudge
+    echo "$output" | grep -q "DISPLAY"
+
+    # send-keys with inbox should NOT have occurred
+    ! grep -q "send-keys.*inbox" "$MOCK_LOG"
+}
+
+# --- T-SHOGUN-004: shogun + active pane + no client → send-keys fallthrough ---
+
+@test "T-SHOGUN-004: send_wakeup shogun + active + detached falls through to send-keys" {
+    run bash -c '
+        MOCK_PANE_ACTIVE="1"
+        MOCK_LIST_CLIENTS=""
+        source "'"$TEST_HARNESS"'"
+        AGENT_ID="shogun"
+        send_wakeup 2
+    '
+    [ "$status" -eq 0 ]
+
+    # Should NOT show display-message path
+    ! echo "$output" | grep -q "DISPLAY"
+
+    # Should have used send-keys
+    grep -q "send-keys.*inbox2" "$MOCK_LOG"
 }


### PR DESCRIPTION
## Summary

Fix shogun nudge delivery being permanently locked to display-message in single-pane sessions, causing nudges to be lost when no tmux client is attached.

## Motivation

The shogun session has only one pane, so pane_is_active() always returns true. This meant send-keys was never used — only display-message, which is invisible when no tmux client is connected. 
Nudges were silently lost.

## Changes

  - Add session_has_client() to scripts/inbox_watcher.sh — checks if the tmux session has at least one client attached
  - Update shogun nudge condition: pane_is_active → pane_is_active && session_has_client
  - Add 4 unit tests in tests/unit/test_send_wakeup.bats (T-SHOGUN-001〜004)
  - Extend tmux mock with MOCK_PANE_ACTIVE and MOCK_LIST_CLIENTS control variables

## Testing

  - Unit tests added (4 new tests, all pass)
  - Existing tests unaffected (3 pre-existing failures on main)
  - Manually tested: detached → send-keys; attached → display-message

---

## 概要

将軍セッション(ペイン1つ)でpane_is_active()が常にtrueとなり、send-keys nudgeが永久にdisplay-messageに制限される問題を修正。
（tmux clientが未接続時でもnudgeが消失していた）

## 背景・動機

将軍ペインへのnudge配信では、殿の入力妨害を防ぐためpane_is_active()でペインのアクティブ状態を確認していた。
しかし将軍セッションはペインが1つしかないため、この判定は常にtrue。
結果としてsend-keysが一切使われず、display-messageのみとなっていた。
display-messageはアタッチ中のtmux clientにしか見えないため、clientが接続していない状況ではnudgeが完全に消失していた。

## 変更内容

  - session_has_client() 関数を追加 (scripts/inbox_watcher.sh) — tmuxセッションにclientが接続中か判定
  - 将軍nudge条件を pane_is_active && session_has_client に変更 — 両方trueの場合のみdisplay-messageに制限、それ以外は既存のwake-up経路で配信
  - ユニットテスト4件追加 (tests/unit/test_send_wakeup.bats T-SHOGUN-001〜004)
  - tmux mockに MOCK_PANE_ACTIVE / MOCK_LIST_CLIENTS 制御変数を追加

## テスト

  - ユニットテスト追加済み (4件全PASS)
  - 既存テストへの影響なし (3件の既存失敗はmainでも同一)
  - 手動確認: デタッチ時→send-keys到達、アタッチ時→display-message表示