### PR TITLE
fix: use CLAUDE_PROJECT_DIR for stop hook path resolution

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/stop_hook_inbox.sh",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/stop_hook_inbox.sh\"",
             "timeout": 10
           }
         ]


### PR DESCRIPTION
## Summary
- Stop hookの相対パス (bash scripts/stop_hook_inbox.sh) がCWD不一致時に No such file or directory で失敗する問題を修正
- Claude Code提供の $CLAUDE_PROJECT_DIR 環境変数を使用してパス解決するよう変更

## 変更内容
.claude/settings.json の1行のみ:
```diff
- "command": "bash scripts/stop_hook_inbox.sh"
+ "command": "bash \"\$CLAUDE_PROJECT_DIR/scripts/stop_hook_inbox.sh\""
```

## 動作確認
- 修正前: Stop hook error: Failed with non-blocking status code: bash: scripts/stop_hook_inbox.sh: No such file or directory
- 修正後: エラーなし、stop hookが正常に動作