### PR TITLE
feat: codex reasoning-effort tuning and macOS inbox portability

### DIFF
--- a/scripts/inbox_write.sh
+++ b/scripts/inbox_write.sh
@@ -13,6 +13,7 @@ FROM="${4:-unknown}"
 
 INBOX="$SCRIPT_DIR/queue/inbox/${TARGET}.yaml"
 LOCKFILE="${INBOX}.lock"
+PYTHON_BIN="$SCRIPT_DIR/.venv/bin/python3"
 
 # Validate arguments
 if [ -z "$TARGET" ] || [ -z "$CONTENT" ]; then
@@ -30,76 +31,100 @@ fi
 MSG_ID="msg_$(date +%Y%m%d_%H%M%S)_$(head -c 4 /dev/urandom | xxd -p)"
 TIMESTAMP=$(date "+%Y-%m-%dT%H:%M:%S")
 
-# Atomic write with flock (3 retries)
-attempt=0
-max_attempts=3
+# Prefer project venv, but fall back to system python3.
+if [ ! -x "$PYTHON_BIN" ]; then
+    PYTHON_BIN="$(command -v python3 || true)"
+fi
+if [ -z "$PYTHON_BIN" ]; then
+    echo "[inbox_write] python3 not found" >&2
+    exit 1
+fi
 
-while [ $attempt -lt $max_attempts ]; do
-    if (
-        flock -w 5 200 || exit 1
-
-        # Add message via python3 (unified YAML handling)
-        "$SCRIPT_DIR/.venv/bin/python3" -c "
-import yaml, sys
+# Atomic write with an advisory lock implemented in Python (macOS lacks `flock`(1)).
+# NOTE: Python is invoked with `-` (script from stdin), so message content cannot also be streamed via stdin.
+# Pass content via environment variable; messages are short so this is acceptable in practice.
+env INBOX="$INBOX" LOCKFILE="$LOCKFILE" MSG_ID="$MSG_ID" FROM="$FROM" TIMESTAMP="$TIMESTAMP" TYPE="$TYPE" CONTENT="$CONTENT" \
+    "$PYTHON_BIN" - <<'PY'
+import os, sys, time, tempfile
 
 try:
+    import yaml
+except Exception as e:
+    print(f"ERROR: failed to import yaml: {e}", file=sys.stderr)
+    sys.exit(1)
+
+inbox = os.environ["INBOX"]
+lockfile = os.environ["LOCKFILE"]
+msg_id = os.environ["MSG_ID"]
+from_ = os.environ["FROM"]
+timestamp = os.environ["TIMESTAMP"]
+type_ = os.environ["TYPE"]
+content = os.environ.get("CONTENT", "")
+
+# Acquire an exclusive advisory lock with a timeout (5s).
+try:
+    import fcntl
+except Exception as e:
+    print(f"ERROR: fcntl unavailable: {e}", file=sys.stderr)
+    sys.exit(1)
+
+os.makedirs(os.path.dirname(inbox), exist_ok=True)
+
+deadline = time.time() + 5.0
+lock_fd = os.open(lockfile, os.O_CREAT | os.O_RDWR, 0o600)
+try:
+    while True:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            break
+        except BlockingIOError:
+            if time.time() >= deadline:
+                print(f"[inbox_write] Lock timeout for {inbox}", file=sys.stderr)
+                sys.exit(1)
+            time.sleep(0.1)
+
     # Load existing inbox
-    with open('$INBOX') as f:
+    with open(inbox, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
 
-    # Initialize if needed
     if not data:
         data = {}
-    if not data.get('messages'):
-        data['messages'] = []
+    if not data.get("messages"):
+        data["messages"] = []
 
-    # Add new message
-    new_msg = {
-        'id': '$MSG_ID',
-        'from': '$FROM',
-        'timestamp': '$TIMESTAMP',
-        'type': '$TYPE',
-        'content': '''$CONTENT''',
-        'read': False
-    }
-    data['messages'].append(new_msg)
+    data["messages"].append(
+        {
+            "id": msg_id,
+            "from": from_,
+            "timestamp": timestamp,
+            "type": type_,
+            "content": content,
+            "read": False,
+        }
+    )
 
-    # Overflow protection: keep max 50 messages
-    if len(data['messages']) > 50:
-        msgs = data['messages']
-        unread = [m for m in msgs if not m.get('read', False)]
-        read = [m for m in msgs if m.get('read', False)]
-        # Keep all unread + newest 30 read messages
-        data['messages'] = unread + read[-30:]
+    # Overflow protection: keep max 50 messages (all unread + newest 30 read).
+    if len(data["messages"]) > 50:
+        msgs = data["messages"]
+        unread = [m for m in msgs if not m.get("read", False)]
+        read = [m for m in msgs if m.get("read", False)]
+        data["messages"] = unread + read[-30:]
 
-    # Atomic write: tmp file + rename (prevents partial reads)
-    import tempfile, os
-    tmp_fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname('$INBOX'), suffix='.tmp')
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(inbox), suffix=".tmp")
     try:
-        with os.fdopen(tmp_fd, 'w') as f:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
             yaml.dump(data, f, default_flow_style=False, allow_unicode=True, indent=2)
-        os.replace(tmp_path, '$INBOX')
-    except:
-        os.unlink(tmp_path)
+        os.replace(tmp_path, inbox)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except Exception:
+            pass
         raise
 
-except Exception as e:
-    print(f'ERROR: {e}', file=sys.stderr)
-    sys.exit(1)
-" || exit 1
-
-    ) 200>"$LOCKFILE"; then
-        # Success
-        exit 0
-    else
-        # Lock timeout or error
-        attempt=$((attempt + 1))
-        if [ $attempt -lt $max_attempts ]; then
-            echo "[inbox_write] Lock timeout for $INBOX (attempt $attempt/$max_attempts), retrying..." >&2
-            sleep 1
-        else
-            echo "[inbox_write] Failed to acquire lock after $max_attempts attempts for $INBOX" >&2
-            exit 1
-        fi
-    fi
-done
+finally:
+    try:
+        os.close(lock_fd)
+    except Exception:
+        pass
+PY


### PR DESCRIPTION
# 殿への上申（本PRの趣旨）
殿、此度の改修は「Codex運用の実戦性向上」と「macOSでの安定稼働確保」を主眼とした兵站整備でござる。

## 主要戦果
- `scripts/inbox_watcher.sh`
  - `fswatch` / `inotifywait` が無い環境でも polling に退避し、監視任務を継続可能化。
  - busy時は `send-keys` 注入を抑えつつ `display-message` で `inboxN` を掲示し、未読取りこぼしを抑制。
- `scripts/inbox_write.sh`
  - `flock(1)` 依存を外し、Python `fcntl` による排他へ変更（macOS互換）。
  - `.venv` の Python 優先、無ければ system `python3` に退避。
- `shutsujin_departure.sh` / `lib/cli_adapter.sh`
  - Codex起動導線を整理し、エージェント別の運用設定を強化。

## 明示事項（今回のご指示）
- **Claudeでモデル指定を切り替えるのと同趣旨で、Codex側でも思考深度（reasoning effort）を調整可能**にしてございます。
- 具体的には、エージェント単位で Codex の reasoning effort を変更できるよう起動・アダプタ側を整備しており、任務の重さに応じて深掘り度を運用調整できます。

## 差分の評価
- 差分の大半は、想定どおり「Codexを快適に使用するための運用改善（起動・指示・ドキュメント）」でござる。
- それに加え、本PRは `macOS` における inbox基盤の実行互換性を高める実装差分を含み、快適化だけでなく可搬性の底上げも成しております。

## 主な変更ファイル
- `scripts/inbox_watcher.sh`
- `scripts/inbox_write.sh`
- `lib/cli_adapter.sh`
- `shutsujin_departure.sh`
- `instructions/cli_specific/codex_tools.md`
- `instructions/generated/codex-ashigaru.md`
- `instructions/generated/codex-gunshi.md`
- `instructions/generated/codex-karo.md`
- `instructions/generated/codex-shogun.md`
- `skills/skill-creator/SKILL.md`

何卒、ご査収のほどお願い奉ります。
