### PR TITLE
fix: align codex routing policy and keep macOS inbox portability

### DIFF
--- a/shutsujin_departure.sh
+++ b/shutsujin_departure.sh
@@ -604,14 +604,12 @@ if [ "$CLI_ADAPTER_LOADED" = true ]; then
                 fi
                 ;;
             codex)
-                # settings.yamlのmodelを優先表示、なければconfig.tomlのeffort
+                # settings.yaml の model を優先表示。未指定時は汎用 codex 表示。
                 _codex_model=$(get_agent_model "$_agent")
                 if [[ -n "$_codex_model" ]]; then
                     MODEL_NAMES[$i]="codex/${_codex_model}"
                 else
-                    _codex_effort=$(grep '^model_reasoning_effort' ~/.codex/config.toml 2>/dev/null | head -1 | sed 's/.*= *"\(.*\)"/\1/')
-                    _codex_effort=${_codex_effort:-high}
-                    MODEL_NAMES[$i]="codex/${_codex_effort}"
+                    MODEL_NAMES[$i]="codex"
                 fi
                 ;;
             copilot)


### PR DESCRIPTION
# 殿への再上申（家老殿ご指摘対応）
家老殿のご査閲、痛み入りまする。ご指摘に従い、`reasoning_effort` の個別調整機構を本PRより除外いたしました。

## 対応内容
- 除外:
  - `lib/cli_adapter.sh` の `get_codex_reasoning_effort()` と関連実装
  - `shutsujin_departure.sh` 内の `model_reasoning_effort` 参照
- 維持:
  - `scripts/inbox_watcher.sh` の macOS/Linux 監視フォールバック（`fswatch`/`inotifywait` 不在時 polling）
  - `scripts/inbox_write.sh` の `fcntl` 排他による macOS 互換化
  - Codex 起動導線および文書整備

## 方針整合
v3.5 の Bloom Dynamic Model Routing 方針
「タスクの認知的複雑さに応じて適切なモデルを選定する」
に合わせ、`reasoning_effort` の個別チューニングは撤去済みです。

## 付記
- 本PRは、先行PR #52 の指摘反映版（再提出）でございます。

何卒ご査収のほど、お願い奉りまする。
