### PR TITLE
fix(e2e): add fallback for .venv/bin/python3 in E2E temp directory

### DIFF
--- a/tests/e2e/helpers/setup.bash
+++ b/tests/e2e/helpers/setup.bash
@@ -44,9 +44,17 @@ setup_e2e_session() {
         cp "$PROJECT_ROOT/config/settings.yaml" "$E2E_QUEUE/config/" 2>/dev/null || true
     fi
 
-    # Link .venv for inbox_write.sh (uses $SCRIPT_DIR/.venv/bin/python3)
+    # Link .venv for inbox_watcher.sh (uses $SCRIPT_DIR/.venv/bin/python3)
     if [ -d "$PROJECT_ROOT/.venv" ]; then
         ln -sf "$PROJECT_ROOT/.venv" "$E2E_QUEUE/.venv"
+    fi
+    # Fallback: if the symlink target is broken or .venv didn't exist at
+    # PROJECT_ROOT, create a minimal .venv/bin/python3 pointing to the
+    # system python3 so inbox_watcher can still find a working interpreter.
+    if [ ! -x "$E2E_QUEUE/.venv/bin/python3" ] && command -v python3 &>/dev/null; then
+        rm -f "$E2E_QUEUE/.venv"  # remove broken symlink if any
+        mkdir -p "$E2E_QUEUE/.venv/bin"
+        ln -sf "$(command -v python3)" "$E2E_QUEUE/.venv/bin/python3"
     fi
 
     # Initialize empty inboxes


### PR DESCRIPTION
## Summary

- Add a fallback in `tests/e2e/helpers/setup.bash` to ensure `.venv/bin/python3` is always available in the E2E temp directory
- When the symlink to `PROJECT_ROOT/.venv` is broken or doesn't exist, creates a minimal `.venv/bin/` with a symlink to the system `python3`

## Problem

`inbox_watcher.sh` uses `$SCRIPT_DIR/.venv/bin/python3` for YAML parsing (e.g., `get_unread_count_fast()`). In E2E tests, scripts run from a temp directory (`/tmp/e2e_queue_XXXXXX/`) where `.venv` is created as a symlink to `PROJECT_ROOT/.venv`.

However, when the symlink target doesn't resolve correctly (observed in GitHub Actions CI), `inbox_watcher.sh` crashes with:

```
/tmp/e2e_queue_XXXXXX/.venv/bin/python3: No such file or directory
```

This causes the E2E Tests (Mock CLI) job to fail even though the Python venv was correctly set up by the CI workflow.

## Fix

After the existing symlink creation, add a verification + fallback:

```bash
if [ ! -x "$E2E_QUEUE/.venv/bin/python3" ] && command -v python3 &>/dev/null; then
    rm -f "$E2E_QUEUE/.venv"  # remove broken symlink if any
    mkdir -p "$E2E_QUEUE/.venv/bin"
    ln -sf "$(command -v python3)" "$E2E_QUEUE/.venv/bin/python3"
fi
```

## Test plan

- [ ] E2E Tests (Mock CLI) pass in CI without `.venv` at `PROJECT_ROOT`
- [ ] E2E Tests still work when `PROJECT_ROOT/.venv` exists (symlink path unchanged)
- [ ] `inbox_watcher.sh` YAML parsing functions work in both scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)