### PR TITLE
fix(stop-hook): avoid shell quoting crash in inbox summary

### DIFF
--- a/scripts/stop_hook_inbox.sh
+++ b/scripts/stop_hook_inbox.sh
@@ -150,30 +150,35 @@ fi
 # The flag will be removed naturally when the agent starts its next turn
 # (Claude Code removes it via the busy detection mechanism).
 
-# ─── Extract unread message summaries ───
-SUMMARY=$(python3 -c "
-import yaml, sys, json
+# ─── Extract unread message summaries and build block JSON ───
+# Use a single python3 call with env vars to avoid shell quoting issues.
+# The old approach embedded $SUMMARY in triple-quotes, which broke when
+# inbox content contained quotes or special characters.
+__STOP_HOOK_INBOX="$INBOX" __STOP_HOOK_AGENT_ID_OUT="$AGENT_ID" \
+__STOP_HOOK_UNREAD_COUNT="$UNREAD_COUNT" \
+python3 -c "
+import json, os, yaml
+
+inbox = os.environ['__STOP_HOOK_INBOX']
+agent_id = os.environ['__STOP_HOOK_AGENT_ID_OUT']
+count = int(os.environ['__STOP_HOOK_UNREAD_COUNT'])
+
+summary = ''
 try:
-    with open('$INBOX', 'r') as f:
+    with open(inbox, 'r') as f:
         data = yaml.safe_load(f)
     msgs = data.get('messages', []) if data else []
     unread = [m for m in msgs if not m.get('read', True)]
     parts = []
-    for m in unread[:5]:  # Max 5 messages in summary
+    for m in unread[:5]:
         frm = m.get('from', '?')
         typ = m.get('type', '?')
         content = str(m.get('content', ''))[:80]
         parts.append(f'[{frm}/{typ}] {content}')
-    print(' | '.join(parts))
-except Exception as e:
-    print(f'inbox parse error: {e}')
-" 2>/dev/null || echo "inbox未読${UNREAD_COUNT}件あり")
+    summary = ' | '.join(parts)
+except Exception:
+    summary = f'inbox未読{count}件あり'
 
-# ─── Block the stop — feed inbox info back to agent ───
-python3 -c "
-import json
-count = $UNREAD_COUNT
-summary = '''$SUMMARY'''
-reason = f'inbox未読{count}件あり。queue/inbox/${AGENT_ID}.yamlを読んで処理せよ。内容: {summary}'
+reason = f'inbox未読{count}件あり。queue/inbox/{agent_id}.yamlを読んで処理せよ。内容: {summary}'
 print(json.dumps({'decision': 'block', 'reason': reason}, ensure_ascii=False))
 " 2>/dev/null || echo "{\"decision\":\"block\",\"reason\":\"inbox未読${UNREAD_COUNT}件あり。queue/inbox/${AGENT_ID}.yamlを読んで処理せよ。\"}"


### PR DESCRIPTION
## Summary
- Stop hook の inbox サマリー生成で `$SUMMARY` を Python triple-quotes (`'''$SUMMARY'''`) に展開していた箇所を修正
- inbox 内容にクオートや特殊文字が含まれると python3 がパースエラーを起こし、エージェントが stop-hook エラーの無限ループに陥る問題を解消

## Motivation
実運用中に家老(karo)エージェントが stop hook エラーで応答不能になった。inbox メッセージに日本語テキストやシングルクオートが含まれており、シェル変数展開→triple-quotes 埋め込みの2段階でクオートが壊れていた。

## Changes
- `scripts/stop_hook_inbox.sh`: 2段階の python3 呼び出し(SUMMARY生成→JSON生成)を、環境変数渡しの1回の python3 呼び出しに統合
  - `__STOP_HOOK_INBOX`, `__STOP_HOOK_AGENT_ID_OUT`, `__STOP_HOOK_UNREAD_COUNT` を env 経由で渡す
  - シェル変数のクオート問題を完全に排除

## Testing
- [x] `shellcheck scripts/stop_hook_inbox.sh` PASS
- [x] `make lint` PASS
- [x] 実環境で家老エージェントの stop hook が正常動作することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)