### PR TITLE
fix: prevent inbox self-send loop and done-state re-report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ task_status_transitions:
   - "assigned → failed (ashigaru fails)"
   - "pending_blocked（家老キュー保留）→ assigned（依存完了後に割当）"
   - "RULE: Ashigaru updates OWN yaml only. Never touch other ashigaru's yaml."
+  - "RULE: On /clear recovery, if assigned=done → DO NOT re-send report. Wait idle. (prevents duplicate report loop)"
   - "RULE: blocked状態タスクを足軽へ事前割当しない。前提完了までpending_tasksで保留。"
 
 # Status definitions are authoritative in:
@@ -81,10 +82,11 @@ Lightweight recovery using only CLAUDE.md (auto-loaded). Do NOT read instruction
 ```
 Step 1: tmux display-message -t "$TMUX_PANE" -p '#{@agent_id}' → ashigaru{N} or gunshi
 Step 2: (gunshi only) mcp__memory__read_graph (skip on failure). Ashigaru skip — task YAML is sufficient.
-Step 3: Read queue/tasks/{your_id}.yaml → assigned=work, idle=wait
+Step 3: Read queue/tasks/{your_id}.yaml →
+        assigned=work (execute task), idle=wait, done=wait (DO NOT re-report)
 Step 4: If task has "project:" field → read context/{project}.md
         If task has "target_path:" → read that file
-Step 5: Start work
+Step 5: Start work (only if assigned=work)
 ```
 
 **CRITICAL**: Steps 1-3を完了するまでinbox処理するな。`inboxN` nudgeが先に届いても無視し、自己識別を必ず先に終わらせよ。

--- a/scripts/inbox_write.sh
+++ b/scripts/inbox_write.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # inbox_write.sh — メールボックスへのメッセージ書き込み（排他ロック付き）
-# Usage: bash scripts/inbox_write.sh <target_agent> <content> [type] [from]
+# Usage: bash scripts/inbox_write.sh <target_agent> <content> <type> <from>
 # Example: bash scripts/inbox_write.sh karo "足軽5号、任務完了" report_received ashigaru5
 
 set -e
@@ -8,15 +8,21 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TARGET="$1"
 CONTENT="$2"
-TYPE="${3:-wake_up}"
-FROM="${4:-unknown}"
+TYPE="$3"
+FROM="$4"
 
 INBOX="$SCRIPT_DIR/queue/inbox/${TARGET}.yaml"
 LOCKFILE="${INBOX}.lock"
 
 # Validate arguments
-if [ -z "$TARGET" ] || [ -z "$CONTENT" ]; then
-    echo "Usage: inbox_write.sh <target_agent> <content> [type] [from]" >&2
+if [ -z "$TARGET" ] || [ -z "$CONTENT" ] || [ -z "$TYPE" ] || [ -z "$FROM" ]; then
+    echo "Usage: inbox_write.sh <target_agent> <content> <type> <from>" >&2
+    exit 1
+fi
+
+# Self-send guard: reject messages where sender == target
+if [ "$FROM" = "$TARGET" ]; then
+    echo "[inbox_write] REJECTED: self-send detected (from=$FROM, target=$TARGET)" >&2
     exit 1
 fi
 

--- a/tests/test_inbox_write.bats
+++ b/tests/test_inbox_write.bats
@@ -75,6 +75,26 @@ teardown() {
 }
 
 # =============================================================================
+# T-002b: 引数バリデーション — type/from未指定でexit 1
+# =============================================================================
+
+@test "T-002b: missing type and from → exit 1" {
+    run bash "$TEST_INBOX_WRITE" "test_agent" "content only"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Usage" ]]
+}
+
+# =============================================================================
+# T-002c: 自己送信ガード — from==targetでexit 1
+# =============================================================================
+
+@test "T-002c: self-send (from==target) → exit 1 with REJECTED" {
+    run bash "$TEST_INBOX_WRITE" "karo" "self message" "cmd_new" "karo"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "REJECTED" ]]
+}
+
+# =============================================================================
 # T-003: 正常書き込み — 新規inboxファイル作成
 # =============================================================================
 
@@ -149,8 +169,8 @@ EOF
 
 @test "T-005: message ID uniqueness → 2 rapid writes produce different IDs" {
     # 2回連続書き込み
-    bash "$TEST_INBOX_WRITE" "test_agent" "メッセージA"
-    bash "$TEST_INBOX_WRITE" "test_agent" "メッセージB"
+    bash "$TEST_INBOX_WRITE" "test_agent" "メッセージA" "test_type" "sender_a"
+    bash "$TEST_INBOX_WRITE" "test_agent" "メッセージB" "test_type" "sender_b"
 
     # python3で検証
     "$VENV_PYTHON" <<EOF
@@ -174,24 +194,10 @@ EOF
 # T-006: デフォルト値 — type未指定でwake_up
 # =============================================================================
 
-@test "T-006: type/from default values → type=wake_up, from=unknown when not specified" {
+@test "T-006: missing type/from → exit 1 with Usage message" {
     run bash "$TEST_INBOX_WRITE" "test_agent" "デフォルトテスト"
-    [ "$status" -eq 0 ]
-
-    # python3で検証
-    "$VENV_PYTHON" <<EOF
-import yaml
-
-with open('$TEST_INBOX_DIR/test_agent.yaml') as f:
-    data = yaml.safe_load(f)
-
-msg = data['messages'][0]
-
-assert msg['type'] == 'wake_up', f'Expected type=wake_up, got {msg["type"]}'
-assert msg['from'] == 'unknown', f'Expected from=unknown, got {msg["from"]}'
-
-print('T-006: PASS')
-EOF
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Usage" ]]
 }
 
 # =============================================================================
@@ -245,7 +251,7 @@ with open('$TEST_INBOX_DIR/test_agent.yaml', 'w') as f:
 EOF
 
     # 新規メッセージ1件書き込み
-    run bash "$TEST_INBOX_WRITE" "test_agent" "新規メッセージ"
+    run bash "$TEST_INBOX_WRITE" "test_agent" "新規メッセージ" "test_type" "other_sender"
     [ "$status" -eq 0 ]
 
     # 検証: 合計50件以下、新規メッセージは存在
@@ -305,7 +311,7 @@ with open('$TEST_INBOX_DIR/test_agent.yaml', 'w') as f:
 EOF
 
     # 新規メッセージ1件書き込み（未読20→21件になる）
-    run bash "$TEST_INBOX_WRITE" "test_agent" "新規未読"
+    run bash "$TEST_INBOX_WRITE" "test_agent" "新規未読" "test_type" "other_sender"
     [ "$status" -eq 0 ]
 
     # 検証: 未読21件が全て保持される
@@ -380,7 +386,7 @@ EOF
 ブレース: {key: value}
 配列: [1, 2, 3]"
 
-    run bash "$TEST_INBOX_WRITE" "test_agent" "$SPECIAL_CONTENT"
+    run bash "$TEST_INBOX_WRITE" "test_agent" "$SPECIAL_CONTENT" "test_type" "other_sender"
     [ "$status" -eq 0 ]
 
     # 検証: 特殊文字が正しく保存・復元されること
@@ -416,7 +422,7 @@ EOF
     [ ! -d "$TEST_INBOX_DIR" ]
 
     # メッセージ書き込み
-    run bash "$TEST_INBOX_WRITE" "test_agent" "自動作成テスト"
+    run bash "$TEST_INBOX_WRITE" "test_agent" "自動作成テスト" "test_type" "other_sender"
     [ "$status" -eq 0 ]
 
     # ディレクトリとファイルが作成されていることを確認


### PR DESCRIPTION
## Summary

- **inbox_write.sh**: Add self-send guard (`from == target` → reject) and make `type`/`from` arguments mandatory
- **CLAUDE.md**: Add `/clear` recovery rule — agents with `assigned=done` must wait idle, not re-send completion reports

## Background

Observed in production:
1. Ashigaru agents in `assigned=done` state re-sent completion reports on every `/clear` recovery, flooding Karo's inbox and causing processing loops
2. Karo sent a `report_completed` message to itself via `inbox_write.sh karo "..." report_completed karo`, creating a self-addressed message

## Changes

### `scripts/inbox_write.sh`
- Reject messages where `FROM == TARGET` (self-send guard)
- Make `type` and `from` required arguments (no more `unknown` default that bypasses the guard)
- All existing callers (`ntfy_listener.sh`, `stop_hook_inbox.sh`, agent instructions) already pass 4 arguments — no breaking changes

### `CLAUDE.md`
- `/clear Recovery` Step 3: `done=wait (DO NOT re-report)` added
- `task_status_transitions`: New rule documenting the done-state behavior

## Test plan

- [ ] `bash scripts/inbox_write.sh karo "test" cmd_new karo` → should be rejected with `REJECTED: self-send detected`
- [ ] `bash scripts/inbox_write.sh karo "test" cmd_new shogun` → should succeed
- [ ] `bash scripts/inbox_write.sh karo "test"` → should fail with usage error (missing type/from)
- [ ] Existing scripts (`ntfy_listener.sh`, `stop_hook_inbox.sh`) continue to work without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)