### PR TITLE
Git側に反映されていなかったので反映

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,7 @@ tests/specs/osato_lms_*
 
 # CI/CD
 !.github/
+!.github/FUNDING.yml
 !.github/workflows/
 !.github/workflows/*.yml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.4.2] - 2026-04-10
+
+### Added
+- `first_setup.sh`: auto-install OSS skills to `~/.claude/skills/` on setup (skips existing, idempotent)
+
 ## [4.4.1] - 2026-03-28
 
 ### Added

--- a/first_setup.sh
+++ b/first_setup.sh
@@ -573,6 +573,45 @@ fi
 RESULTS+=("ディレクトリ構造: OK (作成:$CREATED_COUNT, 既存:$EXISTED_COUNT)")
 
 # ============================================================
+# STEP 6.5: OSSスキルインストール
+# ============================================================
+log_step "STEP 6.5: OSSスキルインストール"
+
+CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
+mkdir -p "$CLAUDE_SKILLS_DIR"
+
+INSTALLED_SKILLS=0
+SKIPPED_SKILLS=0
+FOUND_SKILLS=0
+
+shopt -s nullglob
+for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+    [ -d "$skill_dir" ] || continue
+
+    FOUND_SKILLS=$((FOUND_SKILLS + 1))
+    skill_name=$(basename "$skill_dir")
+    target="$CLAUDE_SKILLS_DIR/$skill_name"
+
+    if [ -d "$target" ]; then
+        log_info "スキル $skill_name は既に存在します（スキップ）"
+        SKIPPED_SKILLS=$((SKIPPED_SKILLS + 1))
+    else
+        cp -r "$skill_dir" "$target"
+        log_success "スキルをインストールしました: $skill_name"
+        INSTALLED_SKILLS=$((INSTALLED_SKILLS + 1))
+    fi
+done
+shopt -u nullglob
+
+if [ "$FOUND_SKILLS" -eq 0 ]; then
+    log_warn "インストール可能なスキルが見つかりませんでした"
+    RESULTS+=("OSSスキル: スキップ (skills/ 未検出)")
+else
+    log_info "/shogun-model-switch などのスキルが使用可能になりました"
+    RESULTS+=("OSSスキル: OK (新規:$INSTALLED_SKILLS, 既存:$SKIPPED_SKILLS)")
+fi
+
+# ============================================================
 # STEP 7: 設定ファイル初期化
 # ============================================================
 log_step "STEP 7: 設定ファイル確認"


### PR DESCRIPTION
`first_setup.sh`: auto-install OSS skills to `~/.claude/skills/` on setup (skips existing, idempotent) (#117)

