### PR TITLE
fix: persona recovery via SessionStart hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/session_start_hook.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@
 !scripts/seo_qc.py
 !scripts/seo_qc.sh
 !scripts/stop_hook_inbox.sh
+!scripts/session_start_hook.sh
 !scripts/agent_status.sh
 !scripts/ratelimit_check.sh
 !scripts/switch_cli.sh

--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@
 !saytask/streaks.yaml.sample
 
 # Reports (private — not tracked)
+logs/
 
 # Memory (MEMORY.md is private; only the sample template is OSS)
 !memory/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,37 +92,17 @@ Step 4: Start work (only if assigned=work)
 
 Forbidden after /clear (ashigaru): reading instructions/*.md (1st task), polling (F004), contacting humans directly (F002). Trust task YAML only — pre-/clear memory is gone.
 
-## /clear Recovery (karo / gunshi — command-layer agents)
+## /clear・compaction Recovery (karo / gunshi / shogun — command-layer agents)
 
-**軽量復帰は不可**。家老は persona + dashboard 責務 + inbox 三重責任、軍師は戦略 state + QC 責務を持つ command-layer agent ゆえ、/clear 後は **Session Start 完全手順（Step 1-5 全て）を必ず実行**せよ。
+Persona・戦国口調・forbidden_actions の再確立は **SessionStart hook** (`scripts/session_start_hook.sh`, matcher=`clear`/`compact`) が自動注入する。手順詳細は hook 側を正とする。
 
-```
-Step 1: tmux display-message -t "$TMUX_PANE" -p '#{@agent_id}' → karo or gunshi
-Step 2: mcp__memory__read_graph — restore rules, preferences, lessons
-Step 3: (karo only) Read memory/MEMORY.md if present
-Step 4: **Read instructions/{your_id}.md** — 絶対省略不可。persona・speech style・forbidden_actions を再確立
-Step 5: Rebuild state from YAML (queue/tasks/, queue/inbox/, queue/reports/), then start work
-```
-
-**Forbidden after /clear (karo/gunshi)**:
-- auto-recovery メッセージの「task YAML 再読」だけで業務再開すること — 必ず Step 4 の instructions/*.md 再読を先に済ませよ
+**Forbidden after /clear・compaction**:
 - persona 確立前に足軽/軍師報告を大量処理すること（三人称化・役職混乱の原因）
 - 自 pane の `tmux capture-pane` 実行（自己観察ループの入口）
-
-**Rationale**: 2026-04-18 の家老役職混乱事例にて、auto-recovery prompt が task YAML のみ再読を指示し instructions/karo.md を迂回した結果、persona 不在のまま業務復帰し三人称化・メタ反省ループが発生した。command-layer agent は軽量復帰不可。
 
 ## Summary Generation (compaction)
 
 Always include: 1) Agent role (shogun/karo/ashigaru/gunshi) 2) Forbidden actions list 3) Current task ID (cmd_xxx)
-
-## Post-Compaction Recovery (CRITICAL)
-
-After compaction, the system instructs "Continue the conversation from where it left off." **This does NOT exempt you from re-reading your instructions file.** Compaction summaries do NOT preserve persona or speech style.
-
-**Mandatory**: After compaction, before resuming work, execute Session Start Step 4:
-- Read your instructions file (shogun→`instructions/shogun.md`, etc.)
-- Restore persona and speech style (戦国口調 for shogun/karo)
-- Then resume the conversation naturally
 
 # Communication Protocol
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,23 +75,41 @@ language:
 
 **CRITICAL**: dashboard.md is secondary data (karo's summary). Primary data = YAML files. Always verify from YAML.
 
-## /clear Recovery (ashigaru/gunshi only)
+## /clear Recovery (ashigaru only)
 
 Lightweight recovery using only CLAUDE.md (auto-loaded). Do NOT read instructions/*.md (cost saving).
 
 ```
-Step 1: tmux display-message -t "$TMUX_PANE" -p '#{@agent_id}' → ashigaru{N} or gunshi
-Step 2: (gunshi only) mcp__memory__read_graph (skip on failure). Ashigaru skip — task YAML is sufficient.
-Step 3: Read queue/tasks/{your_id}.yaml →
+Step 1: tmux display-message -t "$TMUX_PANE" -p '#{@agent_id}' → ashigaru{N}
+Step 2: Read queue/tasks/{your_id}.yaml →
         assigned=work (execute task), idle=wait, done=wait (DO NOT re-report)
-Step 4: If task has "project:" field → read context/{project}.md
+Step 3: If task has "project:" field → read context/{project}.md
         If task has "target_path:" → read that file
-Step 5: Start work (only if assigned=work)
+Step 4: Start work (only if assigned=work)
 ```
 
-**CRITICAL**: Steps 1-3を完了するまでinbox処理するな。`inboxN` nudgeが先に届いても無視し、自己識別を必ず先に終わらせよ。
+**CRITICAL**: Steps 1-2を完了するまでinbox処理するな。`inboxN` nudgeが先に届いても無視し、自己識別を必ず先に終わらせよ。
 
-Forbidden after /clear: reading instructions/*.md (1st task), polling (F004), contacting humans directly (F002). Trust task YAML only — pre-/clear memory is gone.
+Forbidden after /clear (ashigaru): reading instructions/*.md (1st task), polling (F004), contacting humans directly (F002). Trust task YAML only — pre-/clear memory is gone.
+
+## /clear Recovery (karo / gunshi — command-layer agents)
+
+**軽量復帰は不可**。家老は persona + dashboard 責務 + inbox 三重責任、軍師は戦略 state + QC 責務を持つ command-layer agent ゆえ、/clear 後は **Session Start 完全手順（Step 1-5 全て）を必ず実行**せよ。
+
+```
+Step 1: tmux display-message -t "$TMUX_PANE" -p '#{@agent_id}' → karo or gunshi
+Step 2: mcp__memory__read_graph — restore rules, preferences, lessons
+Step 3: (karo only) Read memory/MEMORY.md if present
+Step 4: **Read instructions/{your_id}.md** — 絶対省略不可。persona・speech style・forbidden_actions を再確立
+Step 5: Rebuild state from YAML (queue/tasks/, queue/inbox/, queue/reports/), then start work
+```
+
+**Forbidden after /clear (karo/gunshi)**:
+- auto-recovery メッセージの「task YAML 再読」だけで業務再開すること — 必ず Step 4 の instructions/*.md 再読を先に済ませよ
+- persona 確立前に足軽/軍師報告を大量処理すること（三人称化・役職混乱の原因）
+- 自 pane の `tmux capture-pane` 実行（自己観察ループの入口）
+
+**Rationale**: 2026-04-18 の家老役職混乱事例にて、auto-recovery prompt が task YAML のみ再読を指示し instructions/karo.md を迂回した結果、persona 不在のまま業務復帰し三人称化・メタ反省ループが発生した。command-layer agent は軽量復帰不可。
 
 ## Summary Generation (compaction)
 

--- a/scripts/inbox_watcher.sh
+++ b/scripts/inbox_watcher.sh
@@ -334,23 +334,14 @@ try:
             pass  # If task YAML is unreadable, proceed with auto-recovery as safety net
 
     now = datetime.datetime.now(datetime.timezone.utc).astimezone()
-    # Command-layer agents (karo, gunshi, shogun) need full persona re-establishment
-    # after /clear. Auto-recovery with task YAML alone bypasses Session Start Step 4
-    # (instructions/*.md re-read), causing persona drift / role confusion.
-    # Ashigaru keeps lightweight recovery (task YAML only) per CLAUDE.md.
-    if agent_id in ("karo", "gunshi", "shogun"):
-        content = (
-            f"[auto-recovery] /clear 後の再着手通知。"
-            f"**最優先**: instructions/{agent_id}.md を再読し persona・speech style・forbidden_actions を再確立せよ。"
-            f"その後、queue/tasks/{agent_id}.yaml および queue/inbox/{agent_id}.yaml を再読し、assigned タスク/未読メッセージを処理せよ。"
-        )
-    else:
-        content = (
+    # Persona re-establishment on /clear is handled by SessionStart hook
+    # (scripts/session_start_hook.sh, matcher=clear). Auto-recovery message only
+    # ensures task resumption after the /clear inbox nudge is consumed.
+    msg = {
+        "content": (
             f"[auto-recovery] /clear 後の再着手通知。"
             f"queue/tasks/{agent_id}.yaml を再読し、assigned タスクを即時再開せよ。"
-        )
-    msg = {
-        "content": content,
+        ),
         "from": "inbox_watcher",
         "id": f"msg_auto_recovery_{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}",
         "read": False,

--- a/scripts/inbox_watcher.sh
+++ b/scripts/inbox_watcher.sh
@@ -334,11 +334,23 @@ try:
             pass  # If task YAML is unreadable, proceed with auto-recovery as safety net
 
     now = datetime.datetime.now(datetime.timezone.utc).astimezone()
-    msg = {
-        "content": (
+    # Command-layer agents (karo, gunshi, shogun) need full persona re-establishment
+    # after /clear. Auto-recovery with task YAML alone bypasses Session Start Step 4
+    # (instructions/*.md re-read), causing persona drift / role confusion.
+    # Ashigaru keeps lightweight recovery (task YAML only) per CLAUDE.md.
+    if agent_id in ("karo", "gunshi", "shogun"):
+        content = (
+            f"[auto-recovery] /clear 後の再着手通知。"
+            f"**最優先**: instructions/{agent_id}.md を再読し persona・speech style・forbidden_actions を再確立せよ。"
+            f"その後、queue/tasks/{agent_id}.yaml および queue/inbox/{agent_id}.yaml を再読し、assigned タスク/未読メッセージを処理せよ。"
+        )
+    else:
+        content = (
             f"[auto-recovery] /clear 後の再着手通知。"
             f"queue/tasks/{agent_id}.yaml を再読し、assigned タスクを即時再開せよ。"
-        ),
+        )
+    msg = {
+        "content": content,
         "from": "inbox_watcher",
         "id": f"msg_auto_recovery_{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}",
         "read": False,

--- a/scripts/session_start_hook.sh
+++ b/scripts/session_start_hook.sh
@@ -11,6 +11,11 @@
 #   以降、起動時に Session Start が発火せず、persona 未確立で「自己紹介して」に対し
 #   全エージェントが「我は将軍」と誤認する事故が発生 (2026-04-19)。
 #   SessionStart hook で確定的に Session Start 手順を注入し、/clear・compaction も同時カバーする。
+#
+# Note: ashigaru5(Codex CLI), ashigaru6(Codex CLI) は Claude Code hook 対象外。
+# この hook は Claude Code セッションのみで発火する。
+# Codex CLI 環境では TMUX_PANE が設定されても @agent_id が未設定のため
+# silent exit となり、ログも残らない（正常動作）。
 
 set -uo pipefail
 
@@ -23,6 +28,11 @@ fi
 if [ -z "$AGENT_ID" ]; then
     exit 0
 fi
+
+LOG_DIR="$(dirname "$0")/../logs"
+mkdir -p "$LOG_DIR" || true
+echo "[$(date -Iseconds)] $AGENT_ID session_start_hook fired" \
+    >> "$LOG_DIR/session_start_hook.log" || true
 
 case "$AGENT_ID" in
     shogun|karo|gunshi)

--- a/scripts/session_start_hook.sh
+++ b/scripts/session_start_hook.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SessionStart hook — 起動/resume//clear/compact 全経路で Session Start 手順を確定的に注入
+#
+# 公式仕様 (hooks-guide.md):
+#   - matcher: startup / resume / clear / compact (全 matcher で発火させる)
+#   - stdout の plain text は additionalContext として Claude の context に注入される
+#   - exit 0 で正常終了。失敗しても black hole にならぬよう set -e は使わず graceful degrade
+#
+# 本 hook の目的:
+#   shutsujin_departure.sh の STEP 6.7 (起動時 inbox broadcast) 廃止 (commit 485ab9f, 2026-02-08)
+#   以降、起動時に Session Start が発火せず、persona 未確立で「自己紹介して」に対し
+#   全エージェントが「我は将軍」と誤認する事故が発生 (2026-04-19)。
+#   SessionStart hook で確定的に Session Start 手順を注入し、/clear・compaction も同時カバーする。
+
+set -uo pipefail
+
+AGENT_ID=""
+if [ -n "${TMUX_PANE:-}" ]; then
+    AGENT_ID=$(tmux display-message -t "$TMUX_PANE" -p '#{@agent_id}' 2>/dev/null || true)
+fi
+
+# @agent_id 未設定 (= multi-agent 環境外の個人 Claude Code) → silent exit で干渉せぬ
+if [ -z "$AGENT_ID" ]; then
+    exit 0
+fi
+
+case "$AGENT_ID" in
+    shogun|karo|gunshi)
+        # command-layer agents: full Session Start (Step 1-5)
+        cat <<EOF
+**CRITICAL: Session Start 手順を最優先で実行せよ**
+
+貴殿は **${AGENT_ID}** である。tmux pane から確定的に読み出した事実であり、推測不要。
+
+以下を順番に実行せよ (省略禁止、ユーザ応答/inbox 処理はこの後):
+
+1. \`tmux display-message -t "\$TMUX_PANE" -p '#{@agent_id}'\` で自己識別を再確認
+2. \`mcp__memory__read_graph\` でルール・嗜好・教訓を復元
+3. (shogun のみ) \`memory/MEMORY.md\` を Read
+4. \`instructions/${AGENT_ID}.md\` を最後まで必読 — persona・戦国口調・forbidden_actions 再確立 **(絶対省略禁止)**
+5. \`queue/\` 配下 (tasks/, inbox/, reports/) から state 再構築
+
+**Step 1-4 完了まで inbox 処理・ユーザ応答は禁止**。inbox{N} nudge が先に届いても無視し、persona 確立を優先せよ。
+
+Rationale: 2026-04-18 に家老が「我は将軍」と役職誤認する persona 崩壊事例あり。
+command-layer agent は persona + 戦国口調 + forbidden_actions の再確立が必須。
+
+なお、本メッセージは SessionStart hook (scripts/session_start_hook.sh) が
+tmux pane の @agent_id を読み出して生成したものであり、推測や混同の余地はない。
+EOF
+        ;;
+    ashigaru*)
+        # worker agents: /clear Recovery (ashigaru only) 準拠の軽量手順
+        cat <<EOF
+**CRITICAL: Session Start 手順を最優先で実行せよ**
+
+貴殿は **${AGENT_ID}** である。tmux pane から確定的に読み出した事実。
+
+足軽用軽量手順 (CLAUDE.md「/clear Recovery (ashigaru only)」準拠):
+
+1. \`queue/tasks/${AGENT_ID}.yaml\` を Read
+   - status=assigned かつ work → タスク実行
+   - idle → 待機
+   - done → 待機 (再報告禁止)
+2. タスクに \`project:\` があれば \`context/{project}.md\` を Read
+3. タスクに \`target_path:\` があれば対象ファイルを Read
+4. Step 1-3 完了後にタスク着手
+
+**Step 1-2 完了まで inbox 処理・ユーザ応答は禁止**。
+初回起動時は CLAUDE.md 自動ロード済み、instructions/ashigaru.md の再読は不要 (コスト節約)。
+
+本メッセージは SessionStart hook (scripts/session_start_hook.sh) が
+tmux pane の @agent_id を読み出して生成したものであり、推測や混同の余地はない。
+EOF
+        ;;
+    *)
+        cat <<EOF
+**Session Start**: agent_id=${AGENT_ID}。CLAUDE.md の Session Start 手順に従い自己の instructions/*.md を読み込め。
+EOF
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
## Summary
- Command-layer agents (shogun/karo/gunshi) were observed identifying
  themselves as "Shogun" regardless of their actual role after
  shutsujin_departure.sh STEP 6.7 was removed in 485ab9f. Without that
  step, Session Start procedure was no longer guaranteed to fire on
  cold boot, leaving persona establishment dependent on the first
  user input.
- This PR introduces a SessionStart hook (scripts/session_start_hook.sh)
  that reads the tmux @agent_id pane variable and injects Session Start
  instructions via additionalContext on every startup/resume/clear/compact
  path. Redundant /clear-recovery prose in CLAUDE.md is removed in
  favor of the hook being the single source of truth.
- A firing log (logs/session_start_hook.log) is appended so incidents
  can be audited retrospectively.

## Changes
- scripts/session_start_hook.sh (new)
- .claude/settings.json (register SessionStart hook)
- .gitignore (whitelist session_start_hook.sh, ignore logs/)
- scripts/inbox_watcher.sh (persona re-read in command-layer auto-recovery)
- CLAUDE.md (consolidate /clear & compaction recovery into hook)

## Notes
- Codex CLI agents (ashigaru5/6 in our env) are out of scope by design;
  the hook is Claude-Code specific.
- Verified in our env 2026-04-20 01:13: 8 Claude agents all logged
  `fired` in logs/session_start_hook.log after /clear.