### PR TITLE
feat(bloom-routing): add tier-aware fallback to find_agent_for_model

### DIFF
--- a/lib/cli_adapter.sh
+++ b/lib/cli_adapter.sh
@@ -1015,16 +1015,18 @@ except Exception:
 #   $1: recommended_model — get_recommended_model() の返り値
 #
 # 返り値:
-#   空き足軽ID (例: "ashigaru4") — 完全一致またはフォールバック
+#   空き足軽ID (例: "ashigaru4") — 完全一致または上位tierフォールバック
+#   "SWITCH:<agent_id>:<required_model>" — 下位tierフォールバック (呼び出し元がmodel-switch要)
 #   全員ビジー → "QUEUE"
 #   エラー → "" (空文字)
 #
 # 使用例:
 #   agent=$(find_agent_for_model "claude-sonnet-4-6")
 #   case "$agent" in
-#     QUEUE) echo "待機キューに積む" ;;
-#     "")    echo "エラー" ;;
-#     *)     echo "足軽: $agent に振る（karo.mdがCLI切り替えを判断）" ;;
+#     QUEUE)    echo "待機キューに積む" ;;
+#     SWITCH:*) echo "model-switch後に使用" ;;
+#     "")       echo "エラー" ;;
+#     *)        echo "足軽: $agent に振る" ;;
 #   esac
 find_agent_for_model() {
     local recommended_model="$1"
@@ -1105,52 +1107,107 @@ except Exception:
         fi
     done
 
-    # フェーズ2: 完全一致が全員ビジー → 任意のアイドル足軽にフォールバック
-    # 殿の方針: 「Codex 5.3が欲しくて Claude Code しか空いていなければ Claude Code で可」
-    # kill/restart は絶対しない。アイドルペインを再利用する。
-    local all_agents
-    all_agents=$("$CLI_ADAPTER_PROJECT_ROOT/.venv/bin/python3" -c "
+    # フェーズ2/3: 完全一致が全員ビジー → tier順フォールバック
+    # フェーズ2: 上位tier（max_bloom高い）を先に探す → agent_idをそのまま返す
+    # フェーズ3: 下位tier（max_bloom低い）を次に探す → "SWITCH:<agent_id>:<required_model>" 形式で返す
+    local tiers_output upper_tier lower_tier
+    tiers_output=$("$CLI_ADAPTER_PROJECT_ROOT/.venv/bin/python3" -c "
 import yaml
 
 try:
     with open('${settings}') as f:
         cfg = yaml.safe_load(f) or {}
+    tiers = cfg.get('capability_tiers', {})
     agents = cfg.get('cli', {}).get('agents', {})
-    results = [k for k in agents if k.startswith('ashigaru')]
-    results.sort(key=lambda x: int(x.replace('ashigaru', '')) if x.replace('ashigaru', '').isdigit() else 99)
-    print(' '.join(results))
+    candidates_set = set('${candidates}'.split()) if '${candidates}' else set()
+
+    def get_max_bloom(model):
+        spec = tiers.get(model)
+        if isinstance(spec, dict):
+            return spec.get('max_bloom', 0)
+        return 0
+
+    req_bloom = get_max_bloom('${recommended_model}')
+
+    def sort_key(x):
+        num = x.replace('ashigaru', '')
+        return int(num) if num.isdigit() else 99
+
+    upper_tier = []
+    lower_tier = []
+    for agent_id in sorted(agents.keys(), key=sort_key):
+        if not agent_id.startswith('ashigaru'):
+            continue
+        if agent_id in candidates_set:
+            continue
+        spec = agents[agent_id]
+        if not isinstance(spec, dict):
+            continue
+        agent_bloom = get_max_bloom(spec.get('model', ''))
+        if agent_bloom > req_bloom:
+            upper_tier.append(agent_id)
+        elif 0 < agent_bloom < req_bloom:
+            lower_tier.append(agent_id)
+
+    print(' '.join(upper_tier))
+    print(' '.join(lower_tier))
 except Exception:
-    pass
+    print('')
+    print('')
 " 2>/dev/null)
 
-    local fallback
-    for fallback in $all_agents; do
-        # 既に candidates でチェック済みはスキップ
-        if [[ " $candidates " == *" $fallback "* ]]; then
-            continue
-        fi
+    local tiers_lines
+    mapfile -t tiers_lines <<< "$tiers_output"
+    local upper_tier="${tiers_lines[0]:-}"
+    local lower_tier="${tiers_lines[1]:-}"
 
-        local fb_pane
-        fb_pane=$(tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{@agent_id}' 2>/dev/null \
-            | awk -v agent="$fallback" '$2 == agent {print $1}' | head -1)
+    # フェーズ2: 上位tierアイドルを探す
+    local upper_agent
+    for upper_agent in $upper_tier; do
+        local up_pane
+        up_pane=$(tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{@agent_id}' 2>/dev/null \
+            | awk -v agent="$upper_agent" '$2 == agent {print $1}' | head -1)
 
-        if [[ -z "$fb_pane" ]]; then
-            # tmuxセッションなし（テスト環境）→ フォールバック候補を返す
-            echo "$fallback"
+        if [[ -z "$up_pane" ]]; then
+            # tmuxセッションなし（テスト環境）→ 上位tier候補をそのまま返す
+            echo "$upper_agent"
             return 0
         fi
 
         if declare -f agent_is_busy_check >/dev/null 2>&1; then
-            agent_is_busy_check "$fb_pane" 2>/dev/null
-            local fb_rc=$?
-            if [[ $fb_rc -eq 1 ]]; then
-                echo "$fallback"
+            agent_is_busy_check "$up_pane" 2>/dev/null
+            local up_rc=$?
+            if [[ $up_rc -eq 1 ]]; then
+                echo "$upper_agent"
                 return 0
             fi
         fi
     done
 
-    # 全足軽ビジー → キュー待ち
+    # フェーズ3: 下位tierアイドルを探す（呼び出し元のmodel-switch要）
+    local lower_agent
+    for lower_agent in $lower_tier; do
+        local lo_pane
+        lo_pane=$(tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{@agent_id}' 2>/dev/null \
+            | awk -v agent="$lower_agent" '$2 == agent {print $1}' | head -1)
+
+        if [[ -z "$lo_pane" ]]; then
+            # tmuxセッションなし（テスト環境）→ SWITCH形式で返す
+            echo "SWITCH:${lower_agent}:${recommended_model}"
+            return 0
+        fi
+
+        if declare -f agent_is_busy_check >/dev/null 2>&1; then
+            agent_is_busy_check "$lo_pane" 2>/dev/null
+            local lo_rc=$?
+            if [[ $lo_rc -eq 1 ]]; then
+                echo "SWITCH:${lower_agent}:${recommended_model}"
+                return 0
+            fi
+        fi
+    done
+
+    # フェーズ4: 全足軽ビジー → キュー待ち
     echo "QUEUE"
     return 0
 }

--- a/tests/unit/test_cli_adapter.bats
+++ b/tests/unit/test_cli_adapter.bats
@@ -123,6 +123,60 @@ YAML
 cli:
   default: kimi
 YAML
+
+    # find_agent_for_model テスト用: 上位tierフォールバック
+    # sonnet足軽なし、opus足軽(ashigaru1)のみ → 上位tierとして ashigaru1 を返す
+    cat > "${TEST_TMP}/settings_find_upper.yaml" << 'YAML'
+capability_tiers:
+  claude-haiku-4-5-20251001:
+    max_bloom: 3
+  claude-sonnet-4-6:
+    max_bloom: 5
+  claude-opus-4-6:
+    max_bloom: 6
+cli:
+  default: claude
+  agents:
+    ashigaru1:
+      type: claude
+      model: claude-opus-4-6
+YAML
+
+    # find_agent_for_model テスト用: 下位tier model-switch
+    # sonnet足軽なし、opus足軽なし、haiku足軽(ashigaru3)のみ → SWITCH:ashigaru3:claude-sonnet-4-6
+    cat > "${TEST_TMP}/settings_find_lower.yaml" << 'YAML'
+capability_tiers:
+  claude-haiku-4-5-20251001:
+    max_bloom: 3
+  claude-sonnet-4-6:
+    max_bloom: 5
+  claude-opus-4-6:
+    max_bloom: 6
+cli:
+  default: claude
+  agents:
+    ashigaru3:
+      type: claude
+      model: claude-haiku-4-5-20251001
+YAML
+
+    # find_agent_for_model テスト用: 完全一致回帰
+    # sonnet足軽(ashigaru2)が存在 → ashigaru2 を返す
+    cat > "${TEST_TMP}/settings_find_exact.yaml" << 'YAML'
+capability_tiers:
+  claude-haiku-4-5-20251001:
+    max_bloom: 3
+  claude-sonnet-4-6:
+    max_bloom: 5
+  claude-opus-4-6:
+    max_bloom: 6
+cli:
+  default: claude
+  agents:
+    ashigaru2:
+      type: claude
+      model: claude-sonnet-4-6
+YAML
 }
 
 teardown() {
@@ -747,4 +801,29 @@ YAML
     result=$(build_cli_command "ashigaru5")
     [[ "$result" != MAX_THINKING_TOKENS* ]]
     [[ "$result" == codex* ]]
+}
+
+# =============================================================================
+# find_agent_for_model テスト
+# =============================================================================
+
+@test "find_agent_for_model: 完全一致アイドルあり → 完全一致を返す (回帰)" {
+    # sonnet足軽(ashigaru2)が存在 → ashigaru2 を返す（上位tierより優先）
+    load_adapter_with "${TEST_TMP}/settings_find_exact.yaml"
+    result=$(find_agent_for_model "claude-sonnet-4-6")
+    [ "$result" = "ashigaru2" ]
+}
+
+@test "find_agent_for_model: 完全一致全員ビジー・上位tierアイドルあり → 上位tier返却" {
+    # sonnet足軽なし、opus足軽(ashigaru1)がアイドル → ashigaru1 を返す（SWITCHなし）
+    load_adapter_with "${TEST_TMP}/settings_find_upper.yaml"
+    result=$(find_agent_for_model "claude-sonnet-4-6")
+    [ "$result" = "ashigaru1" ]
+}
+
+@test "find_agent_for_model: 完全一致+上位tier全員ビジー・下位tierのみアイドル → SWITCH返却" {
+    # sonnet足軽なし、opus足軽なし、haiku足軽(ashigaru3)がアイドル → SWITCH形式で返す
+    load_adapter_with "${TEST_TMP}/settings_find_lower.yaml"
+    result=$(find_agent_for_model "claude-sonnet-4-6")
+    [ "$result" = "SWITCH:ashigaru3:claude-sonnet-4-6" ]
 }


### PR DESCRIPTION
## 概要

`lib/cli_adapter.sh` の `find_agent_for_model()` は従来、要求モデルに exact-match するエージェントが全て稼働中の場合、アイドル状態の足軽を無差別にフォールバック先として選んでいた。本PRでは **tier-aware fallback**（階層認識フォールバック）を導入し、上位capability（Sonnet/Opus）のアイドル足軽を優先し、下位tierへフォールバックする際はmodel切替が必要であることを明示的にシグナルする。

### 変更内容

- **`lib/cli_adapter.sh`**: Phase 2（任意アイドルフォールバック）を3段階に分割:
  - Phase 2: 上位tier足軽（max_bloom ≥ 要求tier）→ `agent_id` をそのまま返す
  - Phase 3: 下位tier足軽(max_bloom < 要求tier）→ `SWITCH:<agent_id>:<required_model>` を返す（呼び出し側でmodel切替）
  - Phase 4: アイドル足軽なし → `QUEUE` を返す
- **`tests/unit/test_cli_adapter.bats`**: bats テスト3本追加（exact-match リグレッション / 上位tier fallback / 下位tier `SWITCH` 形式）

### 背景

本機能は **bloom mode=auto** 運用時、`get_recommended_model()` がタスクのbloom levelから推奨 model を決定した後、その model を使える足軽を探す `find_agent_for_model()` のフォールバック挙動を改善するもの。

従来の Phase 2 は、完全一致（exact model）の足軽が全員ビジーのとき、完全一致候補以外の**全 tier 足軽を tier 区別なく `ashigaru` 番号順でアイドル探索**し、最初に見つかったアイドル足軽を返していた。このため:

- 例: L5タスク要求 → Sonnet 足軽全員ビジー → `ashigaru1`(Haiku, 下位tier）がアイドルならそれを返却 → **L5タスクを Haiku で実行（性能不足）**
- 逆に L1タスク要求 → Haiku 全員ビジー → `ashigaru3`(Sonnet）が返却 → **model-switch なしで上位modelをそのまま使用（性能過多の占有）**

新実装では tier を認識し、**『要求modelより高性能な上位tier足軽を使う（性能高すぎだが QUEUE よりマシ）』** フォールバックと、**『下位tier足軽を SWITCH 形式で返して呼び出し元に model-switch を強制する（下位ペインを上位modelに切り替え再起動）』** フォールバックを段階的に試す。これにより、足軽ペインが常に要求tier以上の model で動くことを保証しつつ、上位tier枠の余剰時のみ性能過多を容認する。

## テスト計画

- [ ] `bats tests/unit/test_cli_adapter.bats` — 全テストpass（新規3本含む）
- [ ] `SWITCH:*` 戻り値が家老のルーティングロジックで正しくハンドリングされることを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)