### PR TITLE
fix(inbox_watcher): send startup prompt to Claude agents after /clear

### DIFF
--- a/scripts/inbox_watcher.sh
+++ b/scripts/inbox_watcher.sh
@@ -505,7 +505,7 @@ send_cli_command() {
                 timeout 5 tmux send-keys -t "$PANE_TARGET" Enter 2>/dev/null || true
                 sleep 3
                 # Send startup prompt immediately (don't defer to context-reset cycle)
-                send_codex_startup_prompt
+                send_startup_prompt
                 NEW_CONTEXT_SENT=1
                 return 0
             fi
@@ -554,16 +554,20 @@ send_cli_command() {
     if [[ "$actual_cmd" == "/clear" ]]; then
         LAST_CLEAR_TS=$(date +%s)
         sleep 3
+        # Claude: send startup prompt so agent re-runs Session Start after /clear
+        if [[ "$effective_cli" == "claude" ]]; then
+            send_startup_prompt
+        fi
     else
         sleep 1
     fi
 }
 
-# ─── Send Codex startup prompt after /new ───
+# ─── Send startup prompt after context reset ───
 # Waits for agent to become idle, then sends a startup prompt that includes
 # full recovery steps (identify, read task YAML, read inbox, start work).
 # Called from both send_cli_command (clear_command) and send_context_reset.
-send_codex_startup_prompt() {
+send_startup_prompt() {
     # Poll until agent becomes idle (prompt ready) instead of fixed sleep.
     # Max 15s (3 attempts × 5s). If still busy after 15s, proceed anyway.
     local attempt
@@ -586,7 +590,7 @@ send_codex_startup_prompt() {
     if [[ -z "$startup_prompt" ]]; then
         startup_prompt="Session Start — do ALL of this in one turn, do NOT stop early: 1) tmux display-message to identify yourself. 2) Read queue/tasks/${AGENT_ID}.yaml. 3) Read queue/inbox/${AGENT_ID}.yaml, mark read:true. 4) Read context_files. 5) Execute the assigned task to completion — edit files, run commands, write reports. Keep working until done."
     fi
-    echo "[$(date)] [STARTUP] Sending startup prompt to $AGENT_ID (codex): ${startup_prompt:0:80}..." >&2
+    echo "[$(date)] [STARTUP] Sending startup prompt to $AGENT_ID: ${startup_prompt:0:80}..." >&2
     # Dismiss suggestion UI, then send startup prompt
     timeout 5 tmux send-keys -t "$PANE_TARGET" "x" 2>/dev/null || true
     sleep 0.3
@@ -641,7 +645,7 @@ send_context_reset() {
         timeout 5 tmux send-keys -t "$PANE_TARGET" Enter 2>/dev/null || true
         sleep 3
         # Wait for idle + send startup prompt via shared helper
-        send_codex_startup_prompt
+        send_startup_prompt
         return 0
     fi
 


### PR DESCRIPTION
## 問題

`clear_command` を Claude エージェントに送信した際、`/clear` のみが送られ、その後の startup prompt（Session Start 指示）が送信されない構造的バグが存在していました。

Claude Code は `/clear` 後に CLAUDE.md を自動リロードしますが、startup prompt がなければ Session Start 手順（tmux 自己識別 → task YAML 読み込み → 着手）が実行されません。

## 事故事例

**cmd_211（2026-04-30）**: member2 が `/clear` 後に legend-leader と誤認するインシデントが発生。原因は `/clear` 送信後に startup prompt が未送信だったため、前セッションのペルソナ/役割が継続したこと。

## 修正内容

### 1. `send_codex_startup_prompt` → `send_startup_prompt` にリネーム（CLI agnostic 化）

Codex 専用だった関数名を CLI 種別に依存しない名前に変更。呼び出し箇所（4か所）もすべて更新。

### 2. Claude の `/clear` 完了後に `send_startup_prompt` を呼び出す

`send_cli_command` 内の `/clear` wait ブロックに、`effective_cli == "claude"` の場合のみ `send_startup_prompt` を追加。

```bash
if [[ "$actual_cmd" == "/clear" ]]; then
    LAST_CLEAR_TS=$(date +%s)
    sleep 3
    # Claude: send startup prompt so agent re-runs Session Start after /clear
    if [[ "$effective_cli" == "claude" ]]; then
        send_startup_prompt
    fi
```

## 後方互換性

- Codex の動作は変更なし（`send_startup_prompt` は同じ実装、同じ呼び出し箇所）
- Copilot / Kimi は従来どおり（startup prompt なし）
- Claude のみ `/clear` 後に startup prompt が追加送信される

## 動作確認方法

1. Claude エージェントのペインで `clear_command` を送信
2. `/clear` が送信され、3秒後に startup prompt が送られることを `inbox_watcher.sh` のログで確認
3. エージェントが正しく Session Start 手順を実行し、自己識別 → task 読み込みを行うことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)