### PR TITLE
Add guided agent configurator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@
 !first_setup.sh
 !setup.sh
 !install.bat
+!Configure-Agents.sh
+!Configure-Agents.bat
+!Configure-Agents.command
 
 # Development tooling
 !Makefile
@@ -111,6 +114,7 @@
 !scripts/agent_status.sh
 !scripts/ratelimit_check.sh
 !scripts/switch_cli.sh
+!scripts/configure_agents.py
 !scripts/dashboard-viewer.py
 
 

--- a/Configure-Agents.bat
+++ b/Configure-Agents.bat
@@ -1,0 +1,58 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+chcp 65001 >nul 2>&1
+title multi-agent-shogun Agent Configurator
+
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+
+echo.
+echo   +============================================================+
+echo   ^|  [SHOGUN] multi-agent-shogun - Agent Configurator         ^|
+echo   ^|      Runs agent configuration inside Ubuntu/WSL            ^|
+echo   +============================================================+
+echo.
+
+if not exist "%SCRIPT_DIR%\scripts\configure_agents.py" (
+    echo   [ERROR] scripts\configure_agents.py not found next to this launcher.
+    echo           Run this bat from the multi-agent-shogun folder.
+    echo.
+    pause
+    exit /b 1
+)
+
+wsl.exe -d Ubuntu -- echo test >nul 2>&1
+if %ERRORLEVEL% NEQ 0 (
+    echo   [ERROR] Ubuntu on WSL is not ready.
+    echo           Finish Ubuntu initial setup, then run first_setup.sh in WSL.
+    echo.
+    pause
+    exit /b 1
+)
+
+for /f "usebackq delims=" %%I in (`wsl.exe -d Ubuntu -- wslpath -a "%SCRIPT_DIR%"`) do set "REPO_WSL=%%I"
+if not defined REPO_WSL (
+    echo   [ERROR] Failed to resolve WSL path from:
+    echo           %SCRIPT_DIR%
+    echo.
+    pause
+    exit /b 1
+)
+
+wsl.exe -d Ubuntu -- bash -lc "cd \"%REPO_WSL%\" && python3 scripts/configure_agents.py %*"
+set "CONFIG_EXIT=%ERRORLEVEL%"
+if not "%CONFIG_EXIT%"=="0" (
+    echo.
+    echo   [ERROR] Configurator failed with exit code %CONFIG_EXIT%.
+    echo.
+    pause
+    exit /b %CONFIG_EXIT%
+)
+
+echo.
+echo   [OK] Agent configuration finished.
+echo        Restart runtime with:
+echo        bash shutsujin_departure.sh -c
+echo.
+pause
+exit /b 0

--- a/Configure-Agents.command
+++ b/Configure-Agents.command
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# macOS Finder launcher for Shogun agent configuration.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo ""
+echo "  +============================================================+"
+echo "  |  [SHOGUN] multi-agent-shogun - Agent Configurator          |"
+echo "  |      Choose CLI type per role and active ashigaru count     |"
+echo "  +============================================================+"
+echo ""
+
+if [[ ! -f "scripts/configure_agents.py" ]]; then
+  echo "  [ERROR] scripts/configure_agents.py not found."
+  echo "          Put this .command file in the multi-agent-shogun folder."
+  echo ""
+  read -r -p "Press Enter to close..."
+  exit 1
+fi
+
+python3 scripts/configure_agents.py "$@"
+
+echo ""
+echo "  [OK] Agent configuration finished."
+echo "      Restart runtime with: bash shutsujin_departure.sh -c"
+echo ""
+read -r -p "Press Enter to close..."

--- a/Configure-Agents.sh
+++ b/Configure-Agents.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Configure Shogun role CLI types and active ashigaru count.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo ""
+echo "  +============================================================+"
+echo "  |  [SHOGUN] multi-agent-shogun - Agent Configurator          |"
+echo "  |      Choose CLI type per role and active ashigaru count     |"
+echo "  +============================================================+"
+echo ""
+
+if [[ ! -f "scripts/configure_agents.py" ]]; then
+  echo "  [ERROR] scripts/configure_agents.py not found."
+  echo "          Run this launcher from the multi-agent-shogun folder."
+  exit 1
+fi
+
+python3 scripts/configure_agents.py "$@"
+
+echo ""
+echo "  [OK] Agent configuration finished."
+echo "      Restart runtime with: bash shutsujin_departure.sh -c"

--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ Then restart your computer and run `install.bat` again.
 |--------|---------|-------------|
 | `install.bat` | Windows: WSL2 + Ubuntu setup | First time only |
 | `first_setup.sh` | Install tmux, Node.js, Claude Code CLI + Memory MCP config | First time only |
+| `Configure-Agents.sh` / `.bat` / `.command` | Guided CUI for role CLI assignment and Ashigaru count | When changing formation |
 | `shutsujin_departure.sh` | Create tmux sessions + launch the configured CLI for each agent + load instructions + start ntfy listener | Daily |
 | `scripts/switch_cli.sh` | Live switch agent CLI/model (settings.yaml → /exit → relaunch) | As needed |
 
@@ -584,7 +585,14 @@ Detailed project knowledge (requirements, design, past feedback) lives in `conte
 
 #### 3. Customizing the agent formation
 
-The agent formation (which CLI each agent uses) lives in `config/settings.yaml`:
+The agent formation (which CLI each agent uses) lives in `config/settings.yaml`.
+For guided setup, run the small configurator:
+
+```bash
+bash Configure-Agents.sh
+```
+
+It asks for `cli.default`, then Shogun, Karo, Gunshi, the active Ashigaru count, and each Ashigaru's CLI type. It preserves existing `model`, `variant`, and `thinking` fields by default.
 
 ```yaml
 cli:

--- a/README_ja.md
+++ b/README_ja.md
@@ -451,6 +451,7 @@ wsl --install
 |-----------|------|---------------|
 | `install.bat` | Windows: WSL2 + Ubuntu のセットアップ | 初回のみ |
 | `first_setup.sh` | tmux、Node.js、Claude Code CLI のインストール + Memory MCP設定 | 初回のみ |
+| `Configure-Agents.sh` / `.bat` / `.command` | 役職ごとの CLI と足軽人数を対話式に設定 | 陣営構成を変える時 |
 | `shutsujin_departure.sh` | tmuxセッション作成 + エージェントごとの設定済みCLI起動 + 指示書読み込み + ntfyリスナー起動 | 毎日 |
 | `scripts/switch_cli.sh` | エージェントのCLI/モデルをライブ切替（settings.yaml → /exit → 再起動） | 必要時 |
 
@@ -588,7 +589,14 @@ notes: |
 
 #### 3. エージェント構成のカスタマイズ
 
-陣営構成（誰にどのCLIを使わせるか）は `config/settings.yaml`：
+陣営構成（誰にどのCLIを使わせるか）は `config/settings.yaml`。
+対話式に設定したい場合は、簡易 CUI を使えます：
+
+```bash
+bash Configure-Agents.sh
+```
+
+`cli.default`、将軍、家老、軍師、足軽人数、各足軽の CLI 種別の順に聞きます。既存の `model`、`variant`、`thinking` はデフォルトでは保持します。
 
 ```yaml
 cli:

--- a/scripts/configure_agents.py
+++ b/scripts/configure_agents.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Configure Shogun agent CLI assignments with a small CUI.
+
+This script edits only the coarse formation choices:
+
+- cli.default
+- cli.agents.<role>.type
+- the active ashigaru range represented in cli.agents
+
+Model, variant, and thinking fields are preserved by default so existing
+settings.yaml model routing keeps working.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SETTINGS = ROOT / "config/settings.yaml"
+ALLOWED_CLIS = ("claude", "codex", "copilot", "kimi", "opencode")
+CORE_ROLES = ("shogun", "karo", "gunshi")
+ASHIGARU_RE = re.compile(r"^ashigaru([1-9][0-9]*)$")
+MODEL_PREF_KEYS = ("model", "variant", "thinking", "reasoning_effort", "recommended_model")
+DEFAULT_ASHIGARU_COUNT = 7
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_yaml(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(data, fh, sort_keys=False, allow_unicode=True)
+
+
+def normalize_cli(value: str, *, field: str) -> str:
+    normalized = (value or "").strip().lower()
+    if normalized not in ALLOWED_CLIS:
+        allowed = ", ".join(ALLOWED_CLIS)
+        raise SystemExit(f"{field}: unsupported CLI '{value}'. Allowed: {allowed}")
+    return normalized
+
+
+def normalize_count(value: int) -> int:
+    if value < 1:
+        raise SystemExit("--ashigaru-count must be 1 or greater")
+    return value
+
+
+def ensure_cli_sections(cfg: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    cli = cfg.get("cli")
+    if not isinstance(cli, dict):
+        cli = {}
+        cfg["cli"] = cli
+    agents = cli.get("agents")
+    if not isinstance(agents, dict):
+        agents = {}
+        cli["agents"] = agents
+    return cli, agents
+
+
+def current_cli(cfg: dict[str, Any], role: str, fallback: str) -> str:
+    cli = cfg.get("cli") if isinstance(cfg.get("cli"), dict) else {}
+    agents = cli.get("agents") if isinstance(cli.get("agents"), dict) else {}
+    agent_cfg = agents.get(role) if isinstance(agents, dict) else None
+
+    if isinstance(agent_cfg, dict):
+        value = str(agent_cfg.get("type") or "").strip().lower()
+        if value in ALLOWED_CLIS:
+            return value
+    elif isinstance(agent_cfg, str):
+        value = agent_cfg.strip().lower()
+        if value in ALLOWED_CLIS:
+            return value
+
+    default_cli = str(cli.get("default") or "").strip().lower() if isinstance(cli, dict) else ""
+    if default_cli in ALLOWED_CLIS:
+        return default_cli
+    return fallback
+
+
+def current_ashigaru_count(cfg: dict[str, Any]) -> int:
+    cli = cfg.get("cli") if isinstance(cfg.get("cli"), dict) else {}
+    agents = cli.get("agents") if isinstance(cli.get("agents"), dict) else {}
+    if not isinstance(agents, dict) or "karo" not in agents:
+        return DEFAULT_ASHIGARU_COUNT
+
+    numbers = []
+    for role in agents:
+        if not isinstance(role, str):
+            continue
+        match = ASHIGARU_RE.match(role)
+        if match:
+            numbers.append(int(match.group(1)))
+    if not numbers:
+        return DEFAULT_ASHIGARU_COUNT
+    return max(numbers)
+
+
+def prompt_choice(label: str, default: str) -> str:
+    while True:
+        print("")
+        print(label)
+        for idx, option in enumerate(ALLOWED_CLIS, start=1):
+            suffix = " [default]" if option == default else ""
+            print(f"  {idx}) {option}{suffix}")
+        raw = input("> ").strip()
+        if not raw:
+            return default
+        if raw.isdigit():
+            idx = int(raw)
+            if 1 <= idx <= len(ALLOWED_CLIS):
+                return ALLOWED_CLIS[idx - 1]
+        raw = raw.lower()
+        if raw in ALLOWED_CLIS:
+            return raw
+        print("Input error: choose a CLI type.")
+
+
+def prompt_count(default: int) -> int:
+    while True:
+        print("")
+        raw = input(f"Number of ashigaru (1 or more) [default: {default}]: ").strip()
+        if not raw:
+            return default
+        if raw.isdigit() and int(raw) >= 1:
+            return int(raw)
+        print("Input error: ashigaru count must be an integer greater than or equal to 1.")
+
+
+def set_role_cli(agents: dict[str, Any], role: str, cli_type: str, *, reset_model_prefs: bool) -> None:
+    existing = agents.get(role)
+    if isinstance(existing, dict):
+        role_cfg = copy.deepcopy(existing)
+    else:
+        role_cfg = {}
+    role_cfg["type"] = cli_type
+    if reset_model_prefs:
+        for key in MODEL_PREF_KEYS:
+            role_cfg.pop(key, None)
+    agents[role] = role_cfg
+
+
+def configure(
+    cfg: dict[str, Any],
+    *,
+    default_cli: str,
+    ashigaru_count: int,
+    role_clis: dict[str, str],
+    reset_model_prefs: bool,
+) -> dict[str, Any]:
+    cli, agents = ensure_cli_sections(cfg)
+    cli["default"] = default_cli
+
+    for role in CORE_ROLES:
+        set_role_cli(agents, role, role_clis.get(role, default_cli), reset_model_prefs=reset_model_prefs)
+
+    for i in range(1, ashigaru_count + 1):
+        role = f"ashigaru{i}"
+        set_role_cli(agents, role, role_clis.get(role, default_cli), reset_model_prefs=reset_model_prefs)
+
+    for role in list(agents.keys()):
+        if not isinstance(role, str):
+            continue
+        match = ASHIGARU_RE.match(role)
+        if match and int(match.group(1)) > ashigaru_count:
+            agents.pop(role, None)
+
+    return cfg
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Configure Shogun role CLI types and ashigaru count.")
+    parser.add_argument("--settings", default=str(DEFAULT_SETTINGS), help="settings.yaml path")
+    parser.add_argument("--default", choices=ALLOWED_CLIS, help="cli.default")
+    parser.add_argument("--ashigaru-count", type=int, help="number of active ashigaru")
+    parser.add_argument("--ashigaru-cli", choices=ALLOWED_CLIS, help="default CLI for unspecified ashigaru")
+    parser.add_argument(
+        "--reset-model-prefs",
+        action="store_true",
+        help="remove model/variant/thinking fields for configured roles",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="print updated YAML without writing")
+    for role in CORE_ROLES:
+        parser.add_argument(f"--{role}", choices=ALLOWED_CLIS, help=f"{role} CLI type")
+    for i in range(1, 33):
+        parser.add_argument(f"--ashigaru{i}", choices=ALLOWED_CLIS, help=f"ashigaru{i} CLI type")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    settings_path = Path(args.settings)
+    cfg = load_yaml(settings_path)
+
+    provided_any = any(
+        getattr(args, name) is not None
+        for name in ("default", "ashigaru_count", "ashigaru_cli", *CORE_ROLES)
+    ) or any(getattr(args, f"ashigaru{i}") is not None for i in range(1, 33))
+
+    if args.default:
+        default_cli = normalize_cli(args.default, field="--default")
+    elif provided_any:
+        default_cli = current_cli(cfg, "shogun", "claude")
+    else:
+        default_cli = current_cli(cfg, "shogun", "claude")
+
+    ashigaru_count = normalize_count(args.ashigaru_count) if args.ashigaru_count else current_ashigaru_count(cfg)
+
+    role_clis: dict[str, str] = {}
+    if provided_any:
+        for role in CORE_ROLES:
+            value = getattr(args, role)
+            role_clis[role] = normalize_cli(value, field=f"--{role}") if value else current_cli(cfg, role, default_cli)
+        ashigaru_default = args.ashigaru_cli or default_cli
+        for i in range(1, ashigaru_count + 1):
+            role = f"ashigaru{i}"
+            value = getattr(args, role)
+            role_clis[role] = normalize_cli(value, field=f"--{role}") if value else current_cli(cfg, role, ashigaru_default)
+    else:
+        print("=== Shogun agent configurator ===")
+        print(f"settings: {settings_path}")
+        default_cli = prompt_choice("Select cli.default", default_cli)
+        for role in CORE_ROLES:
+            role_clis[role] = prompt_choice(f"Select CLI for {role}", current_cli(cfg, role, default_cli))
+        ashigaru_count = prompt_count(ashigaru_count)
+        for i in range(1, ashigaru_count + 1):
+            role = f"ashigaru{i}"
+            role_clis[role] = prompt_choice(f"Select CLI for {role}", current_cli(cfg, role, default_cli))
+
+    updated = configure(
+        cfg,
+        default_cli=default_cli,
+        ashigaru_count=ashigaru_count,
+        role_clis=role_clis,
+        reset_model_prefs=args.reset_model_prefs,
+    )
+
+    if args.dry_run:
+        print(yaml.safe_dump(updated, sort_keys=False, allow_unicode=True), end="")
+    else:
+        save_yaml(settings_path, updated)
+        print(f"[OK] updated {settings_path}")
+        print("[OK] model/variant/thinking fields were preserved")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_configure_agent_launchers.bats
+++ b/tests/unit/test_configure_agent_launchers.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+setup() {
+  PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+}
+
+@test "configure agent launchers: Unix wrappers are valid shell and call canonical script" {
+  run bash -n "$PROJECT_ROOT/Configure-Agents.sh"
+  [ "$status" -eq 0 ]
+
+  run bash -n "$PROJECT_ROOT/Configure-Agents.command"
+  [ "$status" -eq 0 ]
+
+  run grep -F "python3 scripts/configure_agents.py" "$PROJECT_ROOT/Configure-Agents.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -F "python3 scripts/configure_agents.py" "$PROJECT_ROOT/Configure-Agents.command"
+  [ "$status" -eq 0 ]
+}
+
+@test "configure agent launchers: Windows wrapper runs canonical script through Ubuntu WSL" {
+  run grep -F "wsl.exe -d Ubuntu" "$PROJECT_ROOT/Configure-Agents.bat"
+  [ "$status" -eq 0 ]
+
+  run grep -F "wslpath -a" "$PROJECT_ROOT/Configure-Agents.bat"
+  [ "$status" -eq 0 ]
+
+  run grep -F "python3 scripts/configure_agents.py" "$PROJECT_ROOT/Configure-Agents.bat"
+  [ "$status" -eq 0 ]
+}

--- a/tests/unit/test_configure_agents.bats
+++ b/tests/unit/test_configure_agents.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+  mkdir -p "$TEST_TMP/scripts" "$TEST_TMP/config"
+  cp "$PROJECT_ROOT/scripts/configure_agents.py" "$TEST_TMP/scripts/configure_agents.py"
+  chmod +x "$TEST_TMP/scripts/configure_agents.py"
+
+  cat > "$TEST_TMP/config/settings.yaml" <<'YAML'
+language: ja
+shell: bash
+cli:
+  default: claude
+  agents:
+    shogun:
+      type: claude
+      model: opus
+      thinking: true
+    karo:
+      type: claude
+      model: sonnet
+    gunshi:
+      type: claude
+      model: opus
+    ashigaru1:
+      type: claude
+      model: sonnet
+    ashigaru2:
+      type: codex
+      model: gpt-5.3-codex
+    ashigaru4:
+      type: opencode
+      model: openrouter/example/stale
+      variant: high
+YAML
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+@test "configure_agents: CLI種別と足軽数を保存し既存model prefsは保持する" {
+  run bash -lc "cd '$TEST_TMP' && python3 scripts/configure_agents.py --default claude --ashigaru-count 3 --shogun codex --karo claude --gunshi opencode --ashigaru1 claude --ashigaru2 codex --ashigaru3 opencode"
+  [ "$status" -eq 0 ]
+
+  run python3 - "$TEST_TMP/config/settings.yaml" <<'PY'
+import sys, yaml
+with open(sys.argv[1], encoding='utf-8') as fh:
+    cfg = yaml.safe_load(fh)
+agents = cfg["cli"]["agents"]
+assert cfg["cli"]["default"] == "claude"
+assert agents["shogun"] == {"type": "codex", "model": "opus", "thinking": True}
+assert agents["karo"] == {"type": "claude", "model": "sonnet"}
+assert agents["gunshi"] == {"type": "opencode", "model": "opus"}
+assert agents["ashigaru1"] == {"type": "claude", "model": "sonnet"}
+assert agents["ashigaru2"] == {"type": "codex", "model": "gpt-5.3-codex"}
+assert agents["ashigaru3"] == {"type": "opencode"}
+assert "ashigaru4" not in agents
+print("ok")
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "configure_agents: --reset-model-prefs では詳細model prefsを削除する" {
+  run bash -lc "cd '$TEST_TMP' && python3 scripts/configure_agents.py --reset-model-prefs --ashigaru-count 1 --shogun codex --karo claude --gunshi claude --ashigaru1 opencode"
+  [ "$status" -eq 0 ]
+
+  run python3 - "$TEST_TMP/config/settings.yaml" <<'PY'
+import sys, yaml
+with open(sys.argv[1], encoding='utf-8') as fh:
+    cfg = yaml.safe_load(fh)
+agents = cfg["cli"]["agents"]
+assert agents["shogun"] == {"type": "codex"}
+assert agents["karo"] == {"type": "claude"}
+assert agents["gunshi"] == {"type": "claude"}
+assert agents["ashigaru1"] == {"type": "opencode"}
+assert "ashigaru2" not in agents
+print("ok")
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "configure_agents: 対話入力は default/core roles/count/ashigaru の順で聞く" {
+  run bash -lc "cd '$TEST_TMP' && printf '%s\n' \
+    'codex' \
+    'claude' \
+    'opencode' \
+    'kimi' \
+    '2' \
+    'copilot' \
+    'codex' \
+    | python3 scripts/configure_agents.py"
+  [ "$status" -eq 0 ]
+
+  run python3 - "$output" <<'PY'
+import sys
+out = sys.argv[1]
+labels = [
+    "Select cli.default",
+    "Select CLI for shogun",
+    "Select CLI for karo",
+    "Select CLI for gunshi",
+    "Number of ashigaru",
+    "Select CLI for ashigaru1",
+    "Select CLI for ashigaru2",
+]
+positions = [out.index(label) for label in labels]
+assert positions == sorted(positions), positions
+PY
+  [ "$status" -eq 0 ]
+
+  run python3 - "$TEST_TMP/config/settings.yaml" <<'PY'
+import sys, yaml
+with open(sys.argv[1], encoding='utf-8') as fh:
+    cfg = yaml.safe_load(fh)
+agents = cfg["cli"]["agents"]
+assert cfg["cli"]["default"] == "codex"
+assert agents["shogun"]["type"] == "claude"
+assert agents["karo"]["type"] == "opencode"
+assert agents["gunshi"]["type"] == "kimi"
+assert agents["ashigaru1"]["type"] == "copilot"
+assert agents["ashigaru2"]["type"] == "codex"
+print("ok")
+PY
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Adds a small guided configurator for assigning Shogun agent CLI types without hand-editing `config/settings.yaml`.

- Adds `scripts/configure_agents.py` for CUI and non-interactive configuration.
- Adds Linux/macOS/Windows launchers: `Configure-Agents.sh`, `Configure-Agents.command`, and `Configure-Agents.bat`.
- Documents the configurator in English and Japanese README script references and formation setup.
- Adds unit tests for the configurator and launchers.

## Behavior

The configurator asks in this order:

1. `cli.default`
2. Shogun
3. Karo
4. Gunshi
5. active Ashigaru count
6. each Ashigaru CLI type

It preserves existing `model`, `variant`, and `thinking` settings by default so current model routing remains intact. Users can pass `--reset-model-prefs` when they intentionally want to clear those detailed fields.

## Validation

- `bash -n Configure-Agents.sh Configure-Agents.command scripts/switch_cli.sh shutsujin_departure.sh`
- `python3 -m py_compile scripts/configure_agents.py`
- `bats tests/unit/test_configure_agents.bats tests/unit/test_configure_agent_launchers.bats`
- `bats tests/unit/test_cli_adapter.bats tests/unit/test_switch_cli.bats tests/unit/test_agent_registry.bats`
- `cmd.exe /c Configure-Agents.bat --dry-run --default claude --ashigaru-count 1 --shogun claude --karo claude --gunshi claude --ashigaru1 claude`
- `git diff --check`
