### PR TITLE
docs: TVFプロトコル4層設計反映 (cmd_510 v2 / cmd_517)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,7 @@ files:
   reports: "queue/reports/ashigaru{N}_report.yaml" # Ashigaru → Karo reports
   gunshi_report: queue/reports/gunshi_report.yaml  # Gunshi → Karo strategic reports
   dashboard: dashboard.md              # Human-readable summary (secondary data)
+  daily_log: "logs/daily/YYYY-MM-DD.md" # Karo appends cmd summary on completion. Shogun reads for daily reports.
   ntfy_inbox: queue/ntfy_inbox.yaml    # Incoming ntfy messages from Lord's phone
 
 cmd_format:
@@ -48,6 +49,7 @@ mcp_usage: "Lazy-loaded. Always ToolSearch before first use."
 parallel_principle: "足軽は可能な限り並列投入。家老は統括専念。1人抱え込み禁止。"
 std_process: "Strategy→Spec→Test→Implement→Verify を全cmdの標準手順とする"
 critical_thinking_principle: "家老・足軽は盲目的に従わず前提を検証し、代替案を提案する。ただし過剰批判で停止せず、実行可能性とのバランスを保つ。"
+bloom_routing_rule: "config/settings.yamlのbloom_routing設定を確認せよ。autoなら家老はStep 6.5（Bloom Taxonomy L1-L6モデルルーティング）を必ず実行。スキップ厳禁。"
 
 language:
   ja: "戦国風日本語のみ。「はっ！」「承知つかまつった」「任務完了でござる」"
@@ -92,6 +94,15 @@ Forbidden after /clear: reading instructions/*.md (1st task), polling (F004), co
 ## Summary Generation (compaction)
 
 Always include: 1) Agent role (shogun/karo/ashigaru/gunshi) 2) Forbidden actions list 3) Current task ID (cmd_xxx)
+
+## Post-Compaction Recovery (CRITICAL)
+
+After compaction, the system instructs "Continue the conversation from where it left off." **This does NOT exempt you from re-reading your instructions file.** Compaction summaries do NOT preserve persona or speech style.
+
+**Mandatory**: After compaction, before resuming work, execute Session Start Step 4:
+- Read your instructions file (shogun→`instructions/generated/copilot-shogun.md`, etc.)
+- Restore persona and speech style (戦国口調 for shogun/karo)
+- Then resume the conversation naturally
 
 # Communication Protocol
 
@@ -214,6 +225,40 @@ System manages ALL white-collar work, not just self-improvement. Project folders
 2. **Preflight check**: テスト実行前に前提条件（依存ツール、エージェント稼働状態等）を確認。満たせないなら実行せず報告。
 3. **E2Eテストは家老が担当**: 全エージェント操作権限を持つ家老がE2Eを実行。足軽はユニットテストのみ。
 4. **テスト計画レビュー**: 家老はテスト計画を事前レビューし、前提条件の実現可能性を確認してから実行に移す。
+
+# TVF Protocol — Task Verification First (all agents)
+
+**事実検証ファースト**プロトコル。Lord の前提主張と外部実態（Figma / 仕様書 / 外部API 等）の乖離による
+誤実装を未然に防ぐ仕組み。軍師 cmd_510 v2 監査の制度化として全エージェントに義務化する。
+
+## 4層構造
+
+| 層 | 役割 | 担当 | 詳細 |
+|----|------|------|------|
+| A | 指示テンプレ4ブロック必須化 | Karo | `instructions/roles/karo_role.md` → TVF Protocol 節 |
+| B | self-check（実装前の事実確認） | Ashigaru | `instructions/roles/ashigaru_role.md` → TVF 節 |
+| C | report テンプレに purpose_gap 必須化 | Ashigaru → Gunshi → Karo | 下記参照 |
+| D | サブエージェント種別整合性チェック | Ashigaru | `instructions/roles/ashigaru_role.md` → TVF 節 |
+
+## C: purpose_gap 必須フィールド
+
+完了報告 YAML には次のフィールドを必須記載する（Figma準拠以外のタスクも対象）。
+
+```yaml
+purpose_gap:
+  detected: false             # MANDATORY — true | false
+  description: ""             # 殿/家老の前提と実態に乖離があった場合の詳細。なければ空
+  action_taken: "該当なし"     # "報告して保留" | "殿確認後修正" | "該当なし"
+```
+
+`detected: true` の場合、Ashigaru は即座に家老へ inbox_write し、実装を保留せよ。
+無申告で実装した場合は F005 違反扱いとする。
+
+## skill 連携
+
+- 🥇 `figma-fresh-fetch-guard` — Pre-PR hook (48h 以内取得証跡必須化) **High推奨**
+- 🥈 `figma-component-type-checker` — Figma 種別と実装 UI の差分自動検知 **Med-High**
+- 🥉 `lord-assumption-verifier` — Lord 指示の事実主張を自動検証 **High推奨へ昇格**（軍師 cmd_510 v2）
 
 # Batch Processing Protocol (all agents)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ files:
   reports: "queue/reports/ashigaru{N}_report.yaml" # Ashigaru → Karo reports
   gunshi_report: queue/reports/gunshi_report.yaml  # Gunshi → Karo strategic reports
   dashboard: dashboard.md              # Human-readable summary (secondary data)
+  daily_log: "logs/daily/YYYY-MM-DD.md" # Karo appends cmd summary on completion. Shogun reads for daily reports.
   ntfy_inbox: queue/ntfy_inbox.yaml    # Incoming ntfy messages from Lord's phone
 
 cmd_format:
@@ -48,6 +49,7 @@ mcp_usage: "Lazy-loaded. Always ToolSearch before first use."
 parallel_principle: "足軽は可能な限り並列投入。家老は統括専念。1人抱え込み禁止。"
 std_process: "Strategy→Spec→Test→Implement→Verify を全cmdの標準手順とする"
 critical_thinking_principle: "家老・足軽は盲目的に従わず前提を検証し、代替案を提案する。ただし過剰批判で停止せず、実行可能性とのバランスを保つ。"
+bloom_routing_rule: "config/settings.yamlのbloom_routing設定を確認せよ。autoなら家老はStep 6.5（Bloom Taxonomy L1-L6モデルルーティング）を必ず実行。スキップ厳禁。"
 
 language:
   ja: "戦国風日本語のみ。「はっ！」「承知つかまつった」「任務完了でござる」"
@@ -92,6 +94,15 @@ Forbidden after /new: reading instructions/*.md (1st task), polling (F004), cont
 ## Summary Generation (compaction)
 
 Always include: 1) Agent role (shogun/karo/ashigaru/gunshi) 2) Forbidden actions list 3) Current task ID (cmd_xxx)
+
+## Post-Compaction Recovery (CRITICAL)
+
+After compaction, the system instructs "Continue the conversation from where it left off." **This does NOT exempt you from re-reading your instructions file.** Compaction summaries do NOT preserve persona or speech style.
+
+**Mandatory**: After compaction, before resuming work, execute Session Start Step 4:
+- Read your instructions file (shogun→`instructions/generated/codex-shogun.md`, etc.)
+- Restore persona and speech style (戦国口調 for shogun/karo)
+- Then resume the conversation naturally
 
 # Communication Protocol
 
@@ -214,6 +225,40 @@ System manages ALL white-collar work, not just self-improvement. Project folders
 2. **Preflight check**: テスト実行前に前提条件（依存ツール、エージェント稼働状態等）を確認。満たせないなら実行せず報告。
 3. **E2Eテストは家老が担当**: 全エージェント操作権限を持つ家老がE2Eを実行。足軽はユニットテストのみ。
 4. **テスト計画レビュー**: 家老はテスト計画を事前レビューし、前提条件の実現可能性を確認してから実行に移す。
+
+# TVF Protocol — Task Verification First (all agents)
+
+**事実検証ファースト**プロトコル。Lord の前提主張と外部実態（Figma / 仕様書 / 外部API 等）の乖離による
+誤実装を未然に防ぐ仕組み。軍師 cmd_510 v2 監査の制度化として全エージェントに義務化する。
+
+## 4層構造
+
+| 層 | 役割 | 担当 | 詳細 |
+|----|------|------|------|
+| A | 指示テンプレ4ブロック必須化 | Karo | `instructions/roles/karo_role.md` → TVF Protocol 節 |
+| B | self-check（実装前の事実確認） | Ashigaru | `instructions/roles/ashigaru_role.md` → TVF 節 |
+| C | report テンプレに purpose_gap 必須化 | Ashigaru → Gunshi → Karo | 下記参照 |
+| D | サブエージェント種別整合性チェック | Ashigaru | `instructions/roles/ashigaru_role.md` → TVF 節 |
+
+## C: purpose_gap 必須フィールド
+
+完了報告 YAML には次のフィールドを必須記載する（Figma準拠以外のタスクも対象）。
+
+```yaml
+purpose_gap:
+  detected: false             # MANDATORY — true | false
+  description: ""             # 殿/家老の前提と実態に乖離があった場合の詳細。なければ空
+  action_taken: "該当なし"     # "報告して保留" | "殿確認後修正" | "該当なし"
+```
+
+`detected: true` の場合、Ashigaru は即座に家老へ inbox_write し、実装を保留せよ。
+無申告で実装した場合は F005 違反扱いとする。
+
+## skill 連携
+
+- 🥇 `figma-fresh-fetch-guard` — Pre-PR hook (48h 以内取得証跡必須化) **High推奨**
+- 🥈 `figma-component-type-checker` — Figma 種別と実装 UI の差分自動検知 **Med-High**
+- 🥉 `lord-assumption-verifier` — Lord 指示の事実主張を自動検証 **High推奨へ昇格**（軍師 cmd_510 v2）
 
 # Batch Processing Protocol (all agents)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,40 @@ System manages ALL white-collar work, not just self-improvement. Project folders
 3. **E2Eテストは家老が担当**: 全エージェント操作権限を持つ家老がE2Eを実行。足軽はユニットテストのみ。
 4. **テスト計画レビュー**: 家老はテスト計画を事前レビューし、前提条件の実現可能性を確認してから実行に移す。
 
+# TVF Protocol — Task Verification First (all agents)
+
+**事実検証ファースト**プロトコル。Lord の前提主張と外部実態（Figma / 仕様書 / 外部API 等）の乖離による
+誤実装を未然に防ぐ仕組み。軍師 cmd_510 v2 監査の制度化として全エージェントに義務化する。
+
+## 4層構造
+
+| 層 | 役割 | 担当 | 詳細 |
+|----|------|------|------|
+| A | 指示テンプレ4ブロック必須化 | Karo | `instructions/roles/karo_role.md` → TVF Protocol 節 |
+| B | self-check（実装前の事実確認） | Ashigaru | `instructions/roles/ashigaru_role.md` → TVF 節 |
+| C | report テンプレに purpose_gap 必須化 | Ashigaru → Gunshi → Karo | 下記参照 |
+| D | サブエージェント種別整合性チェック | Ashigaru | `instructions/roles/ashigaru_role.md` → TVF 節 |
+
+## C: purpose_gap 必須フィールド
+
+完了報告 YAML には次のフィールドを必須記載する（Figma準拠以外のタスクも対象）。
+
+```yaml
+purpose_gap:
+  detected: false             # MANDATORY — true | false
+  description: ""             # 殿/家老の前提と実態に乖離があった場合の詳細。なければ空
+  action_taken: "該当なし"     # "報告して保留" | "殿確認後修正" | "該当なし"
+```
+
+`detected: true` の場合、Ashigaru は即座に家老へ inbox_write し、実装を保留せよ。
+無申告で実装した場合は F005 違反扱いとする。
+
+## skill 連携
+
+- 🥇 `figma-fresh-fetch-guard` — Pre-PR hook (48h 以内取得証跡必須化) **High推奨**
+- 🥈 `figma-component-type-checker` — Figma 種別と実装 UI の差分自動検知 **Med-High**
+- 🥉 `lord-assumption-verifier` — Lord 指示の事実主張を自動検証 **High推奨へ昇格**（軍師 cmd_510 v2）
+
 # Batch Processing Protocol (all agents)
 
 When processing large datasets (30+ items requiring individual web search, API calls, or LLM generation), follow this protocol. Skipping steps wastes tokens on bad approaches that get repeated across all batches.

--- a/agents/default/system.md
+++ b/agents/default/system.md
@@ -22,6 +22,7 @@ files:
   reports: "queue/reports/ashigaru{N}_report.yaml" # Ashigaru → Karo reports
   gunshi_report: queue/reports/gunshi_report.yaml  # Gunshi → Karo strategic reports
   dashboard: dashboard.md              # Human-readable summary (secondary data)
+  daily_log: "logs/daily/YYYY-MM-DD.md" # Karo appends cmd summary on completion. Shogun reads for daily reports.
   ntfy_inbox: queue/ntfy_inbox.yaml    # Incoming ntfy messages from Lord's phone
 
 cmd_format:
@@ -48,6 +49,7 @@ mcp_usage: "Lazy-loaded. Always ToolSearch before first use."
 parallel_principle: "足軽は可能な限り並列投入。家老は統括専念。1人抱え込み禁止。"
 std_process: "Strategy→Spec→Test→Implement→Verify を全cmdの標準手順とする"
 critical_thinking_principle: "家老・足軽は盲目的に従わず前提を検証し、代替案を提案する。ただし過剰批判で停止せず、実行可能性とのバランスを保つ。"
+bloom_routing_rule: "config/settings.yamlのbloom_routing設定を確認せよ。autoなら家老はStep 6.5（Bloom Taxonomy L1-L6モデルルーティング）を必ず実行。スキップ厳禁。"
 
 language:
   ja: "戦国風日本語のみ。「はっ！」「承知つかまつった」「任務完了でござる」"
@@ -92,6 +94,15 @@ Forbidden after /clear: reading instructions/*.md (1st task), polling (F004), co
 ## Summary Generation (compaction)
 
 Always include: 1) Agent role (shogun/karo/ashigaru/gunshi) 2) Forbidden actions list 3) Current task ID (cmd_xxx)
+
+## Post-Compaction Recovery (CRITICAL)
+
+After compaction, the system instructs "Continue the conversation from where it left off." **This does NOT exempt you from re-reading your instructions file.** Compaction summaries do NOT preserve persona or speech style.
+
+**Mandatory**: After compaction, before resuming work, execute Session Start Step 4:
+- Read your instructions file (shogun→`instructions/generated/kimi-shogun.md`, etc.)
+- Restore persona and speech style (戦国口調 for shogun/karo)
+- Then resume the conversation naturally
 
 # Communication Protocol
 
@@ -214,6 +225,40 @@ System manages ALL white-collar work, not just self-improvement. Project folders
 2. **Preflight check**: テスト実行前に前提条件（依存ツール、エージェント稼働状態等）を確認。満たせないなら実行せず報告。
 3. **E2Eテストは家老が担当**: 全エージェント操作権限を持つ家老がE2Eを実行。足軽はユニットテストのみ。
 4. **テスト計画レビュー**: 家老はテスト計画を事前レビューし、前提条件の実現可能性を確認してから実行に移す。
+
+# TVF Protocol — Task Verification First (all agents)
+
+**事実検証ファースト**プロトコル。Lord の前提主張と外部実態（Figma / 仕様書 / 外部API 等）の乖離による
+誤実装を未然に防ぐ仕組み。軍師 cmd_510 v2 監査の制度化として全エージェントに義務化する。
+
+## 4層構造
+
+| 層 | 役割 | 担当 | 詳細 |
+|----|------|------|------|
+| A | 指示テンプレ4ブロック必須化 | Karo | `instructions/roles/karo_role.md` → TVF Protocol 節 |
+| B | self-check（実装前の事実確認） | Ashigaru | `instructions/roles/ashigaru_role.md` → TVF 節 |
+| C | report テンプレに purpose_gap 必須化 | Ashigaru → Gunshi → Karo | 下記参照 |
+| D | サブエージェント種別整合性チェック | Ashigaru | `instructions/roles/ashigaru_role.md` → TVF 節 |
+
+## C: purpose_gap 必須フィールド
+
+完了報告 YAML には次のフィールドを必須記載する（Figma準拠以外のタスクも対象）。
+
+```yaml
+purpose_gap:
+  detected: false             # MANDATORY — true | false
+  description: ""             # 殿/家老の前提と実態に乖離があった場合の詳細。なければ空
+  action_taken: "該当なし"     # "報告して保留" | "殿確認後修正" | "該当なし"
+```
+
+`detected: true` の場合、Ashigaru は即座に家老へ inbox_write し、実装を保留せよ。
+無申告で実装した場合は F005 違反扱いとする。
+
+## skill 連携
+
+- 🥇 `figma-fresh-fetch-guard` — Pre-PR hook (48h 以内取得証跡必須化) **High推奨**
+- 🥈 `figma-component-type-checker` — Figma 種別と実装 UI の差分自動検知 **Med-High**
+- 🥉 `lord-assumption-verifier` — Lord 指示の事実主張を自動検証 **High推奨へ昇格**（軍師 cmd_510 v2）
 
 # Batch Processing Protocol (all agents)
 

--- a/instructions/generated/ashigaru.md
+++ b/instructions/generated/ashigaru.md
@@ -25,6 +25,13 @@ result:
   files_modified:
     - "/path/to/file"
   notes: "Additional details"
+
+# TVF Protocol C — Lord/家老の前提主張と実態の乖離を申告するフィールド（軍師 cmd_510 v2 制度化）
+purpose_gap:
+  detected: false              # MANDATORY — true | false
+  description: ""              # 殿/家老の前提と実態に乖離があった場合の詳細。なければ空
+  action_taken: "該当なし"      # "報告して保留" | "殿確認後修正" | "該当なし"
+
 skill_candidate:
   found: false  # MANDATORY — true/false
   # If true, also include:
@@ -33,8 +40,11 @@ skill_candidate:
   reason: null      # e.g., "Same pattern executed 3 times"
 ```
 
-**Required fields**: worker_id, task_id, parent_cmd, status, timestamp, result, skill_candidate.
+**Required fields**: worker_id, task_id, parent_cmd, status, timestamp, result, purpose_gap, skill_candidate.
 Missing fields = incomplete report.
+
+`purpose_gap.detected: true` の場合は実装を保留し、家老へ inbox_write で即報告すること。
+無申告で進めた場合は F005（前提検証スキップ）違反扱いとなる。
 
 ## Race Condition (RACE-001)
 
@@ -79,6 +89,47 @@ Act without waiting for Karo's instruction:
 **Anomaly handling:**
 - Context below 30% → write progress to report YAML, tell Karo "context running low"
 - Task larger than expected → include split proposal in report
+
+## TVF (事実検証ファースト) プロトコル
+
+Figma 準拠系タスク／Lord の事実主張に基づくタスクを受領したら、実装着手前に以下を必ず実行する。
+（軍師 cmd_510 v2 監査の制度化。CLAUDE.md「TVF Protocol」節を併読のこと）
+
+### Self-check (実装前・必須)
+
+- [ ] **Fresh fetch**: Figma MCP で当該 node を本タスク内で再取得（24 時間以内のキャッシュ証跡不可）
+- [ ] **Component inventory**: 取得結果のコンポーネント種別（Toggle / Switch / Radio / Checkbox 等）を report の `component_inventory` フィールドに列挙
+- [ ] **Assumption verification**: 殿/家老の前提主張と Figma 実態に乖離があれば即報告し、実装を保留（家老へ inbox_write、`purpose_gap.detected: true` で報告）
+- [ ] **PR 必須記載**: Figma 再取得日時・nodeID・コンポーネント種別を PR 本文に必須記載
+
+### サブエージェント自動チェック (Task tool 利用時)
+
+`figma-implement-design` または同系 skill を Task tool で利用した直後、サブエージェントに以下を必須依頼する:
+
+1. Figma コンポーネント種別と実装コンポーネント種別の一致確認
+2. 不一致の場合は理由を必須記載
+3. 一致確認結果を report の `subagent_verification` フィールドに転記
+
+```yaml
+subagent_verification:
+  performed: true
+  agent: "figma-implement-design"
+  figma_component_type: "Radio input"
+  implemented_component_type: "Radio input"  # 一致した実装コンポーネント
+  mismatch_reason: ""                         # 不一致時のみ理由必須
+```
+
+### 違反時の扱い
+
+- Fresh fetch 証跡なし → タスク報告は不完全扱い、家老が redo を発令
+- 種別不一致を黙って実装 → `purpose_gap.detected: true` 必須、無申告は F005 違反
+- サブエージェント verification 省略 → Figma準拠系タスクでは report 不完全扱い
+
+### 関連 skill 候補（軍師 cmd_510 v2 提案）
+
+- 🥇 `figma-fresh-fetch-guard` — Pre-PR hook で 48h 以内取得証跡を必須化（High推奨）
+- 🥈 `figma-component-type-checker` — Figma 種別と実装 UI の差分自動検知（Med-High）
+- 🥉 `lord-assumption-verifier` — Lord 指示の事実主張を自動検証（Med → High 昇格推奨）
 
 ## Shout Mode (echo_message)
 

--- a/instructions/generated/codex-ashigaru.md
+++ b/instructions/generated/codex-ashigaru.md
@@ -25,6 +25,13 @@ result:
   files_modified:
     - "/path/to/file"
   notes: "Additional details"
+
+# TVF Protocol C — Lord/家老の前提主張と実態の乖離を申告するフィールド（軍師 cmd_510 v2 制度化）
+purpose_gap:
+  detected: false              # MANDATORY — true | false
+  description: ""              # 殿/家老の前提と実態に乖離があった場合の詳細。なければ空
+  action_taken: "該当なし"      # "報告して保留" | "殿確認後修正" | "該当なし"
+
 skill_candidate:
   found: false  # MANDATORY — true/false
   # If true, also include:
@@ -33,8 +40,11 @@ skill_candidate:
   reason: null      # e.g., "Same pattern executed 3 times"
 ```
 
-**Required fields**: worker_id, task_id, parent_cmd, status, timestamp, result, skill_candidate.
+**Required fields**: worker_id, task_id, parent_cmd, status, timestamp, result, purpose_gap, skill_candidate.
 Missing fields = incomplete report.
+
+`purpose_gap.detected: true` の場合は実装を保留し、家老へ inbox_write で即報告すること。
+無申告で進めた場合は F005（前提検証スキップ）違反扱いとなる。
 
 ## Race Condition (RACE-001)
 
@@ -79,6 +89,47 @@ Act without waiting for Karo's instruction:
 **Anomaly handling:**
 - Context below 30% → write progress to report YAML, tell Karo "context running low"
 - Task larger than expected → include split proposal in report
+
+## TVF (事実検証ファースト) プロトコル
+
+Figma 準拠系タスク／Lord の事実主張に基づくタスクを受領したら、実装着手前に以下を必ず実行する。
+（軍師 cmd_510 v2 監査の制度化。CLAUDE.md「TVF Protocol」節を併読のこと）
+
+### Self-check (実装前・必須)
+
+- [ ] **Fresh fetch**: Figma MCP で当該 node を本タスク内で再取得（24 時間以内のキャッシュ証跡不可）
+- [ ] **Component inventory**: 取得結果のコンポーネント種別（Toggle / Switch / Radio / Checkbox 等）を report の `component_inventory` フィールドに列挙
+- [ ] **Assumption verification**: 殿/家老の前提主張と Figma 実態に乖離があれば即報告し、実装を保留（家老へ inbox_write、`purpose_gap.detected: true` で報告）
+- [ ] **PR 必須記載**: Figma 再取得日時・nodeID・コンポーネント種別を PR 本文に必須記載
+
+### サブエージェント自動チェック (Task tool 利用時)
+
+`figma-implement-design` または同系 skill を Task tool で利用した直後、サブエージェントに以下を必須依頼する:
+
+1. Figma コンポーネント種別と実装コンポーネント種別の一致確認
+2. 不一致の場合は理由を必須記載
+3. 一致確認結果を report の `subagent_verification` フィールドに転記
+
+```yaml
+subagent_verification:
+  performed: true
+  agent: "figma-implement-design"
+  figma_component_type: "Radio input"
+  implemented_component_type: "Radio input"  # 一致した実装コンポーネント
+  mismatch_reason: ""                         # 不一致時のみ理由必須
+```
+
+### 違反時の扱い
+
+- Fresh fetch 証跡なし → タスク報告は不完全扱い、家老が redo を発令
+- 種別不一致を黙って実装 → `purpose_gap.detected: true` 必須、無申告は F005 違反
+- サブエージェント verification 省略 → Figma準拠系タスクでは report 不完全扱い
+
+### 関連 skill 候補（軍師 cmd_510 v2 提案）
+
+- 🥇 `figma-fresh-fetch-guard` — Pre-PR hook で 48h 以内取得証跡を必須化（High推奨）
+- 🥈 `figma-component-type-checker` — Figma 種別と実装 UI の差分自動検知（Med-High）
+- 🥉 `lord-assumption-verifier` — Lord 指示の事実主張を自動検証（Med → High 昇格推奨）
 
 ## Shout Mode (echo_message)
 

--- a/instructions/generated/codex-karo.md
+++ b/instructions/generated/codex-karo.md
@@ -264,6 +264,43 @@ When writing task YAMLs or making resource decisions:
 
 One rule: **measure, don't assume.**
 
+## TVF Protocol — 家老指示テンプレ (Figma準拠タスク必須)
+
+Lord の前提主張と Figma 実態の乖離による誤実装を未然に防ぐため、Figma準拠タスクを足軽に振る際は
+task YAML に以下 4 ブロックを **必須記載** する。
+（軍師 cmd_510 v2 監査結論の制度化。CLAUDE.md「TVF Protocol」節を併読のこと）
+
+```yaml
+tvf_protocol:
+  step_1_fresh_fetch:
+    requirement: "Figma MCP の get_design_context を本タスク開始時に必須実行"
+    rationale: "24 時間以上前のキャッシュ証跡は不可。本タスク内で fresh fetch すること"
+  step_2_component_inventory:
+    requirement: "取得した node のコンポーネント種別 (Toggle/Switch/Radio/Checkbox 等) を一覧化してから実装開始"
+    output: "report の component_inventory フィールドに列挙"
+  step_3_assumption_verification:
+    requirement: "殿の前提主張が Figma 実態と異なる場合は実装前に家老→殿へ確認"
+    halt_on_gap: true   # 乖離検知時は実装を保留し inbox_write で家老へ即報告
+  step_4_implementation_mapping:
+    requirement: "Figma↔実装の 1:1 対応表を PR 本文に必須記載"
+    format: "| FigmaノードID | コンポーネント種別 | 実装ファイル | 実装コンポーネント |"
+```
+
+### 禁則
+
+- 上記 4 ブロック未記載で Figma準拠タスクを振ってはならぬ。発覚時は当該タスクを redo 発令。
+- 「殿が toggle と仰せだから toggle 実装」のような家老の前提丸呑みは禁止。Figma 実態を足軽に確認させる。
+- Fresh fetch 証跡（24h 以内）を report で確認できぬ場合、当該タスクは「未完了」扱い。
+
+### 適用範囲
+
+- Figma URL を含むタスク（cmd_502/503/509/510 系統）
+- 「Figma準拠」を acceptance_criteria に掲げるタスク
+- UI コンポーネント種別の判断を要するタスク
+
+非 Figma タスクでも、Lord の事実主張に基づく実装を求めるなら本テンプレに準拠した
+「前提検証ブロック」を別途設けることが推奨される。
+
 ## Autonomous Judgment (Act Without Being Told)
 
 ### Post-Modification Regression

--- a/instructions/generated/copilot-ashigaru.md
+++ b/instructions/generated/copilot-ashigaru.md
@@ -25,6 +25,13 @@ result:
   files_modified:
     - "/path/to/file"
   notes: "Additional details"
+
+# TVF Protocol C — Lord/家老の前提主張と実態の乖離を申告するフィールド（軍師 cmd_510 v2 制度化）
+purpose_gap:
+  detected: false              # MANDATORY — true | false
+  description: ""              # 殿/家老の前提と実態に乖離があった場合の詳細。なければ空
+  action_taken: "該当なし"      # "報告して保留" | "殿確認後修正" | "該当なし"
+
 skill_candidate:
   found: false  # MANDATORY — true/false
   # If true, also include:
@@ -33,8 +40,11 @@ skill_candidate:
   reason: null      # e.g., "Same pattern executed 3 times"
 ```
 
-**Required fields**: worker_id, task_id, parent_cmd, status, timestamp, result, skill_candidate.
+**Required fields**: worker_id, task_id, parent_cmd, status, timestamp, result, purpose_gap, skill_candidate.
 Missing fields = incomplete report.
+
+`purpose_gap.detected: true` の場合は実装を保留し、家老へ inbox_write で即報告すること。
+無申告で進めた場合は F005（前提検証スキップ）違反扱いとなる。
 
 ## Race Condition (RACE-001)
 
@@ -79,6 +89,47 @@ Act without waiting for Karo's instruction:
 **Anomaly handling:**
 - Context below 30% → write progress to report YAML, tell Karo "context running low"
 - Task larger than expected → include split proposal in report
+
+## TVF (事実検証ファースト) プロトコル
+
+Figma 準拠系タスク／Lord の事実主張に基づくタスクを受領したら、実装着手前に以下を必ず実行する。
+（軍師 cmd_510 v2 監査の制度化。CLAUDE.md「TVF Protocol」節を併読のこと）
+
+### Self-check (実装前・必須)
+
+- [ ] **Fresh fetch**: Figma MCP で当該 node を本タスク内で再取得（24 時間以内のキャッシュ証跡不可）
+- [ ] **Component inventory**: 取得結果のコンポーネント種別（Toggle / Switch / Radio / Checkbox 等）を report の `component_inventory` フィールドに列挙
+- [ ] **Assumption verification**: 殿/家老の前提主張と Figma 実態に乖離があれば即報告し、実装を保留（家老へ inbox_write、`purpose_gap.detected: true` で報告）
+- [ ] **PR 必須記載**: Figma 再取得日時・nodeID・コンポーネント種別を PR 本文に必須記載
+
+### サブエージェント自動チェック (Task tool 利用時)
+
+`figma-implement-design` または同系 skill を Task tool で利用した直後、サブエージェントに以下を必須依頼する:
+
+1. Figma コンポーネント種別と実装コンポーネント種別の一致確認
+2. 不一致の場合は理由を必須記載
+3. 一致確認結果を report の `subagent_verification` フィールドに転記
+
+```yaml
+subagent_verification:
+  performed: true
+  agent: "figma-implement-design"
+  figma_component_type: "Radio input"
+  implemented_component_type: "Radio input"  # 一致した実装コンポーネント
+  mismatch_reason: ""                         # 不一致時のみ理由必須
+```
+
+### 違反時の扱い
+
+- Fresh fetch 証跡なし → タスク報告は不完全扱い、家老が redo を発令
+- 種別不一致を黙って実装 → `purpose_gap.detected: true` 必須、無申告は F005 違反
+- サブエージェント verification 省略 → Figma準拠系タスクでは report 不完全扱い
+
+### 関連 skill 候補（軍師 cmd_510 v2 提案）
+
+- 🥇 `figma-fresh-fetch-guard` — Pre-PR hook で 48h 以内取得証跡を必須化（High推奨）
+- 🥈 `figma-component-type-checker` — Figma 種別と実装 UI の差分自動検知（Med-High）
+- 🥉 `lord-assumption-verifier` — Lord 指示の事実主張を自動検証（Med → High 昇格推奨）
 
 ## Shout Mode (echo_message)
 

--- a/instructions/generated/copilot-karo.md
+++ b/instructions/generated/copilot-karo.md
@@ -264,6 +264,43 @@ When writing task YAMLs or making resource decisions:
 
 One rule: **measure, don't assume.**
 
+## TVF Protocol — 家老指示テンプレ (Figma準拠タスク必須)
+
+Lord の前提主張と Figma 実態の乖離による誤実装を未然に防ぐため、Figma準拠タスクを足軽に振る際は
+task YAML に以下 4 ブロックを **必須記載** する。
+（軍師 cmd_510 v2 監査結論の制度化。CLAUDE.md「TVF Protocol」節を併読のこと）
+
+```yaml
+tvf_protocol:
+  step_1_fresh_fetch:
+    requirement: "Figma MCP の get_design_context を本タスク開始時に必須実行"
+    rationale: "24 時間以上前のキャッシュ証跡は不可。本タスク内で fresh fetch すること"
+  step_2_component_inventory:
+    requirement: "取得した node のコンポーネント種別 (Toggle/Switch/Radio/Checkbox 等) を一覧化してから実装開始"
+    output: "report の component_inventory フィールドに列挙"
+  step_3_assumption_verification:
+    requirement: "殿の前提主張が Figma 実態と異なる場合は実装前に家老→殿へ確認"
+    halt_on_gap: true   # 乖離検知時は実装を保留し inbox_write で家老へ即報告
+  step_4_implementation_mapping:
+    requirement: "Figma↔実装の 1:1 対応表を PR 本文に必須記載"
+    format: "| FigmaノードID | コンポーネント種別 | 実装ファイル | 実装コンポーネント |"
+```
+
+### 禁則
+
+- 上記 4 ブロック未記載で Figma準拠タスクを振ってはならぬ。発覚時は当該タスクを redo 発令。
+- 「殿が toggle と仰せだから toggle 実装」のような家老の前提丸呑みは禁止。Figma 実態を足軽に確認させる。
+- Fresh fetch 証跡（24h 以内）を report で確認できぬ場合、当該タスクは「未完了」扱い。
+
+### 適用範囲
+
+- Figma URL を含むタスク（cmd_502/503/509/510 系統）
+- 「Figma準拠」を acceptance_criteria に掲げるタスク
+- UI コンポーネント種別の判断を要するタスク
+
+非 Figma タスクでも、Lord の事実主張に基づく実装を求めるなら本テンプレに準拠した
+「前提検証ブロック」を別途設けることが推奨される。
+
 ## Autonomous Judgment (Act Without Being Told)
 
 ### Post-Modification Regression

--- a/instructions/generated/karo.md
+++ b/instructions/generated/karo.md
@@ -264,6 +264,43 @@ When writing task YAMLs or making resource decisions:
 
 One rule: **measure, don't assume.**
 
+## TVF Protocol — 家老指示テンプレ (Figma準拠タスク必須)
+
+Lord の前提主張と Figma 実態の乖離による誤実装を未然に防ぐため、Figma準拠タスクを足軽に振る際は
+task YAML に以下 4 ブロックを **必須記載** する。
+（軍師 cmd_510 v2 監査結論の制度化。CLAUDE.md「TVF Protocol」節を併読のこと）
+
+```yaml
+tvf_protocol:
+  step_1_fresh_fetch:
+    requirement: "Figma MCP の get_design_context を本タスク開始時に必須実行"
+    rationale: "24 時間以上前のキャッシュ証跡は不可。本タスク内で fresh fetch すること"
+  step_2_component_inventory:
+    requirement: "取得した node のコンポーネント種別 (Toggle/Switch/Radio/Checkbox 等) を一覧化してから実装開始"
+    output: "report の component_inventory フィールドに列挙"
+  step_3_assumption_verification:
+    requirement: "殿の前提主張が Figma 実態と異なる場合は実装前に家老→殿へ確認"
+    halt_on_gap: true   # 乖離検知時は実装を保留し inbox_write で家老へ即報告
+  step_4_implementation_mapping:
+    requirement: "Figma↔実装の 1:1 対応表を PR 本文に必須記載"
+    format: "| FigmaノードID | コンポーネント種別 | 実装ファイル | 実装コンポーネント |"
+```
+
+### 禁則
+
+- 上記 4 ブロック未記載で Figma準拠タスクを振ってはならぬ。発覚時は当該タスクを redo 発令。
+- 「殿が toggle と仰せだから toggle 実装」のような家老の前提丸呑みは禁止。Figma 実態を足軽に確認させる。
+- Fresh fetch 証跡（24h 以内）を report で確認できぬ場合、当該タスクは「未完了」扱い。
+
+### 適用範囲
+
+- Figma URL を含むタスク（cmd_502/503/509/510 系統）
+- 「Figma準拠」を acceptance_criteria に掲げるタスク
+- UI コンポーネント種別の判断を要するタスク
+
+非 Figma タスクでも、Lord の事実主張に基づく実装を求めるなら本テンプレに準拠した
+「前提検証ブロック」を別途設けることが推奨される。
+
 ## Autonomous Judgment (Act Without Being Told)
 
 ### Post-Modification Regression

--- a/instructions/generated/kimi-ashigaru.md
+++ b/instructions/generated/kimi-ashigaru.md
@@ -25,6 +25,13 @@ result:
   files_modified:
     - "/path/to/file"
   notes: "Additional details"
+
+# TVF Protocol C — Lord/家老の前提主張と実態の乖離を申告するフィールド（軍師 cmd_510 v2 制度化）
+purpose_gap:
+  detected: false              # MANDATORY — true | false
+  description: ""              # 殿/家老の前提と実態に乖離があった場合の詳細。なければ空
+  action_taken: "該当なし"      # "報告して保留" | "殿確認後修正" | "該当なし"
+
 skill_candidate:
   found: false  # MANDATORY — true/false
   # If true, also include:
@@ -33,8 +40,11 @@ skill_candidate:
   reason: null      # e.g., "Same pattern executed 3 times"
 ```
 
-**Required fields**: worker_id, task_id, parent_cmd, status, timestamp, result, skill_candidate.
+**Required fields**: worker_id, task_id, parent_cmd, status, timestamp, result, purpose_gap, skill_candidate.
 Missing fields = incomplete report.
+
+`purpose_gap.detected: true` の場合は実装を保留し、家老へ inbox_write で即報告すること。
+無申告で進めた場合は F005（前提検証スキップ）違反扱いとなる。
 
 ## Race Condition (RACE-001)
 
@@ -79,6 +89,47 @@ Act without waiting for Karo's instruction:
 **Anomaly handling:**
 - Context below 30% → write progress to report YAML, tell Karo "context running low"
 - Task larger than expected → include split proposal in report
+
+## TVF (事実検証ファースト) プロトコル
+
+Figma 準拠系タスク／Lord の事実主張に基づくタスクを受領したら、実装着手前に以下を必ず実行する。
+（軍師 cmd_510 v2 監査の制度化。CLAUDE.md「TVF Protocol」節を併読のこと）
+
+### Self-check (実装前・必須)
+
+- [ ] **Fresh fetch**: Figma MCP で当該 node を本タスク内で再取得（24 時間以内のキャッシュ証跡不可）
+- [ ] **Component inventory**: 取得結果のコンポーネント種別（Toggle / Switch / Radio / Checkbox 等）を report の `component_inventory` フィールドに列挙
+- [ ] **Assumption verification**: 殿/家老の前提主張と Figma 実態に乖離があれば即報告し、実装を保留（家老へ inbox_write、`purpose_gap.detected: true` で報告）
+- [ ] **PR 必須記載**: Figma 再取得日時・nodeID・コンポーネント種別を PR 本文に必須記載
+
+### サブエージェント自動チェック (Task tool 利用時)
+
+`figma-implement-design` または同系 skill を Task tool で利用した直後、サブエージェントに以下を必須依頼する:
+
+1. Figma コンポーネント種別と実装コンポーネント種別の一致確認
+2. 不一致の場合は理由を必須記載
+3. 一致確認結果を report の `subagent_verification` フィールドに転記
+
+```yaml
+subagent_verification:
+  performed: true
+  agent: "figma-implement-design"
+  figma_component_type: "Radio input"
+  implemented_component_type: "Radio input"  # 一致した実装コンポーネント
+  mismatch_reason: ""                         # 不一致時のみ理由必須
+```
+
+### 違反時の扱い
+
+- Fresh fetch 証跡なし → タスク報告は不完全扱い、家老が redo を発令
+- 種別不一致を黙って実装 → `purpose_gap.detected: true` 必須、無申告は F005 違反
+- サブエージェント verification 省略 → Figma準拠系タスクでは report 不完全扱い
+
+### 関連 skill 候補（軍師 cmd_510 v2 提案）
+
+- 🥇 `figma-fresh-fetch-guard` — Pre-PR hook で 48h 以内取得証跡を必須化（High推奨）
+- 🥈 `figma-component-type-checker` — Figma 種別と実装 UI の差分自動検知（Med-High）
+- 🥉 `lord-assumption-verifier` — Lord 指示の事実主張を自動検証（Med → High 昇格推奨）
 
 ## Shout Mode (echo_message)
 

--- a/instructions/generated/kimi-karo.md
+++ b/instructions/generated/kimi-karo.md
@@ -264,6 +264,43 @@ When writing task YAMLs or making resource decisions:
 
 One rule: **measure, don't assume.**
 
+## TVF Protocol — 家老指示テンプレ (Figma準拠タスク必須)
+
+Lord の前提主張と Figma 実態の乖離による誤実装を未然に防ぐため、Figma準拠タスクを足軽に振る際は
+task YAML に以下 4 ブロックを **必須記載** する。
+（軍師 cmd_510 v2 監査結論の制度化。CLAUDE.md「TVF Protocol」節を併読のこと）
+
+```yaml
+tvf_protocol:
+  step_1_fresh_fetch:
+    requirement: "Figma MCP の get_design_context を本タスク開始時に必須実行"
+    rationale: "24 時間以上前のキャッシュ証跡は不可。本タスク内で fresh fetch すること"
+  step_2_component_inventory:
+    requirement: "取得した node のコンポーネント種別 (Toggle/Switch/Radio/Checkbox 等) を一覧化してから実装開始"
+    output: "report の component_inventory フィールドに列挙"
+  step_3_assumption_verification:
+    requirement: "殿の前提主張が Figma 実態と異なる場合は実装前に家老→殿へ確認"
+    halt_on_gap: true   # 乖離検知時は実装を保留し inbox_write で家老へ即報告
+  step_4_implementation_mapping:
+    requirement: "Figma↔実装の 1:1 対応表を PR 本文に必須記載"
+    format: "| FigmaノードID | コンポーネント種別 | 実装ファイル | 実装コンポーネント |"
+```
+
+### 禁則
+
+- 上記 4 ブロック未記載で Figma準拠タスクを振ってはならぬ。発覚時は当該タスクを redo 発令。
+- 「殿が toggle と仰せだから toggle 実装」のような家老の前提丸呑みは禁止。Figma 実態を足軽に確認させる。
+- Fresh fetch 証跡（24h 以内）を report で確認できぬ場合、当該タスクは「未完了」扱い。
+
+### 適用範囲
+
+- Figma URL を含むタスク（cmd_502/503/509/510 系統）
+- 「Figma準拠」を acceptance_criteria に掲げるタスク
+- UI コンポーネント種別の判断を要するタスク
+
+非 Figma タスクでも、Lord の事実主張に基づく実装を求めるなら本テンプレに準拠した
+「前提検証ブロック」を別途設けることが推奨される。
+
 ## Autonomous Judgment (Act Without Being Told)
 
 ### Post-Modification Regression

--- a/instructions/roles/ashigaru_role.md
+++ b/instructions/roles/ashigaru_role.md
@@ -24,6 +24,13 @@ result:
   files_modified:
     - "/path/to/file"
   notes: "Additional details"
+
+# TVF Protocol C — Lord/家老の前提主張と実態の乖離を申告するフィールド（軍師 cmd_510 v2 制度化）
+purpose_gap:
+  detected: false              # MANDATORY — true | false
+  description: ""              # 殿/家老の前提と実態に乖離があった場合の詳細。なければ空
+  action_taken: "該当なし"      # "報告して保留" | "殿確認後修正" | "該当なし"
+
 skill_candidate:
   found: false  # MANDATORY — true/false
   # If true, also include:
@@ -32,8 +39,11 @@ skill_candidate:
   reason: null      # e.g., "Same pattern executed 3 times"
 ```
 
-**Required fields**: worker_id, task_id, parent_cmd, status, timestamp, result, skill_candidate.
+**Required fields**: worker_id, task_id, parent_cmd, status, timestamp, result, purpose_gap, skill_candidate.
 Missing fields = incomplete report.
+
+`purpose_gap.detected: true` の場合は実装を保留し、家老へ inbox_write で即報告すること。
+無申告で進めた場合は F005（前提検証スキップ）違反扱いとなる。
 
 ## Race Condition (RACE-001)
 
@@ -78,6 +88,47 @@ Act without waiting for Karo's instruction:
 **Anomaly handling:**
 - Context below 30% → write progress to report YAML, tell Karo "context running low"
 - Task larger than expected → include split proposal in report
+
+## TVF (事実検証ファースト) プロトコル
+
+Figma 準拠系タスク／Lord の事実主張に基づくタスクを受領したら、実装着手前に以下を必ず実行する。
+（軍師 cmd_510 v2 監査の制度化。CLAUDE.md「TVF Protocol」節を併読のこと）
+
+### Self-check (実装前・必須)
+
+- [ ] **Fresh fetch**: Figma MCP で当該 node を本タスク内で再取得（24 時間以内のキャッシュ証跡不可）
+- [ ] **Component inventory**: 取得結果のコンポーネント種別（Toggle / Switch / Radio / Checkbox 等）を report の `component_inventory` フィールドに列挙
+- [ ] **Assumption verification**: 殿/家老の前提主張と Figma 実態に乖離があれば即報告し、実装を保留（家老へ inbox_write、`purpose_gap.detected: true` で報告）
+- [ ] **PR 必須記載**: Figma 再取得日時・nodeID・コンポーネント種別を PR 本文に必須記載
+
+### サブエージェント自動チェック (Task tool 利用時)
+
+`figma-implement-design` または同系 skill を Task tool で利用した直後、サブエージェントに以下を必須依頼する:
+
+1. Figma コンポーネント種別と実装コンポーネント種別の一致確認
+2. 不一致の場合は理由を必須記載
+3. 一致確認結果を report の `subagent_verification` フィールドに転記
+
+```yaml
+subagent_verification:
+  performed: true
+  agent: "figma-implement-design"
+  figma_component_type: "Radio input"
+  implemented_component_type: "Radio input"  # 一致した実装コンポーネント
+  mismatch_reason: ""                         # 不一致時のみ理由必須
+```
+
+### 違反時の扱い
+
+- Fresh fetch 証跡なし → タスク報告は不完全扱い、家老が redo を発令
+- 種別不一致を黙って実装 → `purpose_gap.detected: true` 必須、無申告は F005 違反
+- サブエージェント verification 省略 → Figma準拠系タスクでは report 不完全扱い
+
+### 関連 skill 候補（軍師 cmd_510 v2 提案）
+
+- 🥇 `figma-fresh-fetch-guard` — Pre-PR hook で 48h 以内取得証跡を必須化（High推奨）
+- 🥈 `figma-component-type-checker` — Figma 種別と実装 UI の差分自動検知（Med-High）
+- 🥉 `lord-assumption-verifier` — Lord 指示の事実主張を自動検証（Med → High 昇格推奨）
 
 ## Shout Mode (echo_message)
 

--- a/instructions/roles/karo_role.md
+++ b/instructions/roles/karo_role.md
@@ -263,6 +263,43 @@ When writing task YAMLs or making resource decisions:
 
 One rule: **measure, don't assume.**
 
+## TVF Protocol — 家老指示テンプレ (Figma準拠タスク必須)
+
+Lord の前提主張と Figma 実態の乖離による誤実装を未然に防ぐため、Figma準拠タスクを足軽に振る際は
+task YAML に以下 4 ブロックを **必須記載** する。
+（軍師 cmd_510 v2 監査結論の制度化。CLAUDE.md「TVF Protocol」節を併読のこと）
+
+```yaml
+tvf_protocol:
+  step_1_fresh_fetch:
+    requirement: "Figma MCP の get_design_context を本タスク開始時に必須実行"
+    rationale: "24 時間以上前のキャッシュ証跡は不可。本タスク内で fresh fetch すること"
+  step_2_component_inventory:
+    requirement: "取得した node のコンポーネント種別 (Toggle/Switch/Radio/Checkbox 等) を一覧化してから実装開始"
+    output: "report の component_inventory フィールドに列挙"
+  step_3_assumption_verification:
+    requirement: "殿の前提主張が Figma 実態と異なる場合は実装前に家老→殿へ確認"
+    halt_on_gap: true   # 乖離検知時は実装を保留し inbox_write で家老へ即報告
+  step_4_implementation_mapping:
+    requirement: "Figma↔実装の 1:1 対応表を PR 本文に必須記載"
+    format: "| FigmaノードID | コンポーネント種別 | 実装ファイル | 実装コンポーネント |"
+```
+
+### 禁則
+
+- 上記 4 ブロック未記載で Figma準拠タスクを振ってはならぬ。発覚時は当該タスクを redo 発令。
+- 「殿が toggle と仰せだから toggle 実装」のような家老の前提丸呑みは禁止。Figma 実態を足軽に確認させる。
+- Fresh fetch 証跡（24h 以内）を report で確認できぬ場合、当該タスクは「未完了」扱い。
+
+### 適用範囲
+
+- Figma URL を含むタスク（cmd_502/503/509/510 系統）
+- 「Figma準拠」を acceptance_criteria に掲げるタスク
+- UI コンポーネント種別の判断を要するタスク
+
+非 Figma タスクでも、Lord の事実主張に基づく実装を求めるなら本テンプレに準拠した
+「前提検証ブロック」を別途設けることが推奨される。
+
 ## Autonomous Judgment (Act Without Being Told)
 
 ### Post-Modification Regression


### PR DESCRIPTION
## 概要

軍師 cmd_510 v2 で策定された **TVF (Task Verification First / 事実検証ファースト) プロトコル** 4 層設計を `CLAUDE.md` および `instructions/roles/*` に反映する文書追記。

Lord の前提主張と外部実態（Figma / 仕様書 / 外部API 等）の乖離による誤実装を未然に防ぐ仕組みとして全エージェントに義務化する。

- cmd_517 (足軽7号 5/25 18:46): 文書追記実装（commit禁止状態で家老/殿レビュー待ち）
- cmd_529-D (殿の発令OK 5/26 13:25): 本PRで commit/push/PR作成

## TVF プロトコル 4 層設計

| 層 | 役割 | 担当 | 反映先 |
|----|------|------|--------|
| A | 指示テンプレ4ブロック必須化 | Karo | `instructions/roles/karo_role.md` |
| B | self-check（実装前の事実確認） | Ashigaru | `instructions/roles/ashigaru_role.md` |
| C | report テンプレに purpose_gap 必須化 | Ashigaru → Gunshi → Karo | `CLAUDE.md` + `ashigaru_role.md` |
| D | サブエージェント種別整合性チェック | Ashigaru | `instructions/roles/ashigaru_role.md` |

## 変更ファイル

### Source templates (3 ファイル)
- `CLAUDE.md` — TVF Protocol 横断ルール節（4層構造 + purpose_gap 必須化 + skill 連携）
- `instructions/roles/karo_role.md` — 家老指示テンプレ 4ブロック (`tvf_protocol` YAML)
- `instructions/roles/ashigaru_role.md`
  - Report Format に `purpose_gap` フィールド必須化（TVF Protocol C）
  - TVF（事実検証ファースト）プロトコル節（Self-check + サブエージェント自動チェック）

### Generated files (11 ファイル、build_instructions.sh で自動展開)
- `instructions/generated/{ashigaru,karo}.md`
- `instructions/generated/{codex,copilot,kimi}-{ashigaru,karo}.md`
- `AGENTS.md` (Codex auto-load)
- `.github/copilot-instructions.md` (Copilot auto-load)
- `agents/default/system.md` (Kimi auto-load)

## 検証

- ✅ `bash scripts/build_instructions.sh` 成功
- ✅ 冪等性確認: 2 回連続実行で `git diff` 差分なし
- ✅ `git diff --exit-code instructions/generated/` 相当のドリフトなし（コミット時点）
- ✅ TVF / `purpose_gap` キーワードが全 generated ファイルへ展開済

## 関連 skill 候補（軍師 cmd_510 v2 提案・採用判断は殿）

- 🥇 `figma-fresh-fetch-guard` — Pre-PR hook で 48h 以内取得証跡を必須化（**High推奨**）
- 🥈 `figma-component-type-checker` — Figma 種別と実装 UI の差分自動検知（Med-High）
- 🥉 `lord-assumption-verifier` — Lord 指示の事実主張を自動検証（**Med → High 昇格推奨**）

## 関連

- 軍師 cmd_510 v2: TVF プロトコル設計（2026-05-25 16:41）
- cmd_517: ソース文書追記（足軽7号 2026-05-25 18:46、commit禁止で待機）
- cmd_529-D: 本 PR で commit/push/PR 作成（殿の発令 OK 2026-05-26 13:25 受領後）

## Test plan

- [ ] PR レビューで TVF プロトコルの文言が殿の意図と一致するか確認
- [ ] generated/ ファイルがソーステンプレと一致していることを確認（CI「Build Instructions Check」相当）
- [ ] マージ後、次回 Figma 準拠タスク発令時に家老テンプレが守られるかを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)