### PR TITLE
fix: use relative path for stop hook in .claude/settings.json (closes #160)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash /home/tono/multi-agent-shogun/scripts/stop_hook_inbox.sh",
+            "command": "bash scripts/stop_hook_inbox.sh",
             "timeout": 60
           }
         ]


### PR DESCRIPTION
## 概要 / Summary
Stop hook のコマンドパスが絶対パス `/home/tono/multi-agent-shogun/...` で
ハードコードされており、それ以外のパスにクローンした環境で
`No such file or directory` となり inbox 配送が機能しなくなる問題を修正します。

## 変更内容 / Changes
`.claude/settings.json` の Stop hook command を相対パスに統一:

```diff
-            "command": "bash /home/tono/multi-agent-shogun/scripts/stop_hook_inbox.sh",
+            "command": "bash scripts/stop_hook_inbox.sh",
```

SessionStart hook (`bash scripts/session_start_hook.sh`) と同じ相対パス書式に揃えました。

## 背景 / Motivation
- SessionStart hook は相対パスで正しく動作する一方、Stop hook だけが
  絶対パスでハードコードされていた。
- Stop hook は inbox 配送の要であり、壊れるとエージェント間通信が停止する。
- `scripts/stop_hook_inbox.sh` 自体はリポジトリに存在するため、パスのみの問題。

## テスト / Testing
- リポジトリルートから `bash scripts/stop_hook_inbox.sh` が解決されることを確認。
- 想定: `/home/tono/` 以外にクローンした環境でも Stop hook が発火するようになる。

## 関連 / Related
Closes #160