### PR TITLE
fix: Replace bash4-only lowercase expansion with bash3.2 compatible tr

### DIFF
--- a/lib/cli_adapter.sh
+++ b/lib/cli_adapter.sh
@@ -26,7 +26,7 @@ CLI_ADAPTER_ALLOWED_CLIS="claude codex copilot kimi opencode antigravity"
 # CLI種別の互換aliasを正規名へ正規化する。
 _cli_adapter_normalize_cli_type() {
     local cli_type="${1:-}"
-    cli_type="${cli_type,,}"
+    cli_type="$(echo "$cli_type" | tr '[:upper:]' '[:lower:]')"
     case "$cli_type" in
         gemini|agy) echo "antigravity" ;;
         *)          echo "$cli_type" ;;


### PR DESCRIPTION
## Problem

`lib/cli_adapter.sh` uses the `${var,,}` lowercase expansion syntax which is a **bash 4.0+ feature**. This causes a `bad substitution` error on macOS, where the system `/bin/bash` is version 3.2.

```
lib/cli_adapter.sh: line 29: cli_type=${cli_type,,}: bad substitution
```

## Fix

Replace `${cli_type,,}` with a POSIX-compatible `tr` pipeline:

```bash
# Before (bash 4+ only)
cli_type="${cli_type,,}"

# After (bash 3.2 compatible)
cli_type="$(echo "$cli_type" | tr '[:upper:]' '[:lower:]')"
```

## Compatibility

- ✅ bash 3.2 (macOS default `/bin/bash`)
- ✅ bash 4.x
- ✅ bash 5.x
- ✅ POSIX-compliant (uses `tr` which is universally available)

## Testing

The `tr '[:upper:]' '[:lower:]'` approach correctly lowercases strings on both bash 3.2 and bash 4+, and handles all the alias cases (`gemini`, `agy` → `antigravity`) that the `_cli_adapter_normalize_cli_type` function is designed for.